### PR TITLE
[TRG-1] installer la gouvernance et le socle documentaire

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,77 @@
+# Modèle de configuration locale : `cp .env.example .env` puis ajuster.
+# Ce fichier grandit brique par brique, en même temps que le schéma zod
+# de `api/src/config.ts`.
+
+# Adresse et port d'écoute du serveur HTTP (défauts : 0.0.0.0 / 3000).
+HOST=0.0.0.0
+PORT=3000
+
+# Identifiant renvoyé dans l'en-tête X-Instance-Id. Optionnel : par défaut le
+# nom d'hôte (en conteneur, l'id du conteneur). Utile en local pour distinguer
+# deux instances lancées à la main.
+# INSTANCE_ID=local-1
+
+# Niveau de log pino (fatal|error|warn|info|debug|trace|silent). Défaut : info.
+LOG_LEVEL=info
+
+# Identité de l'exécutable, ajoutée à chaque log structuré. APP_VERSION sera le
+# SHA ou le tag lors du déploiement.
+APP_ENVIRONMENT=local
+APP_VERSION=dev
+
+# Limites HTTP explicites : payload 16 KiB, timeouts de socket/requête et
+# recyclage d'une connexion keep-alive après 1 000 requêtes. L'API est derrière
+# un seul proxy en cloud ; garder TRUST_PROXY_HOPS=0 en accès direct/local.
+BODY_LIMIT_BYTES=16384
+CONNECTION_TIMEOUT_MS=10000
+REQUEST_TIMEOUT_MS=15000
+KEEP_ALIVE_TIMEOUT_MS=5000
+MAX_REQUESTS_PER_SOCKET=1000
+TRUST_PROXY_HOPS=0
+
+# Limite normale par IP observée. Un token de charge distinct augmente le
+# plafond uniquement hors production ; il reste dans GitHub Secrets.
+RATE_LIMIT_MAX=60
+RATE_LIMIT_LOAD_MAX=1000000
+RATE_LIMIT_WINDOW_MS=60000
+# LOAD_TEST_TOKEN=change-this-load-token-at-least-32-characters
+
+# Arrêt gracieux (ms). DELAY = temps entre « /ready → 503 » et l'arrêt des
+# connexions, le temps que le load balancer nous retire du pool. TIMEOUT = délai
+# max de drainage avant sortie forcée. DELAY + TIMEOUT doit rester sous la
+# période de grâce de la plateforme (Azure Container Apps : 30 s).
+SHUTDOWN_DELAY_MS=5000
+SHUTDOWN_TIMEOUT_MS=10000
+
+# Clé d'API attendue dans l'en-tête X-API-Key sur /api/* — obligatoire, aucun
+# défaut. En prod : secret Azure Container Apps. nginx l'injecte côté serveur,
+# elle n'atteint jamais le navigateur.
+API_KEY=change-this-api-key-at-least-32-characters
+
+# Redis privé partagé entre tous les replicas. En lancement direct hors
+# Compose, remplacer `redis` par `127.0.0.1`. Le secret HMAC pseudonymise les
+# identifiants avant toute clé Redis et doit contenir au moins 32 caractères.
+REDIS_URL=redis://redis:6379
+REDIS_HMAC_SECRET=change-this-hmac-secret-at-least-32-characters
+
+# Résilience Redis : timeout par commande, trois échecs avant ouverture, puis
+# une sonde half-open après dix secondes.
+REDIS_COMMAND_TIMEOUT_MS=250
+REDIS_CIRCUIT_FAILURE_THRESHOLD=3
+REDIS_CIRCUIT_RESET_MS=10000
+
+# Idempotence distribuée : réponse 24 h, verrou court pour le single-flight et
+# attente maximale d'un concurrent avant passage fail-safe en mode dégradé.
+IDEMPOTENCY_TTL_SECONDS=86400
+IDEMPOTENCY_LOCK_MS=5000
+IDEMPOTENCY_WAIT_MS=2000
+
+# Réglages des règles de décision — obligatoires, aucun défaut :
+# une valeur absente ou invalide arrête l'application au démarrage. La v1
+# accepte uniquement EUR ; AMOUNT_THRESHOLD est donc un montant en euros.
+# Bornes : montant <= 10^9, vélocité <= 10 000, fenêtre <= 3 600 secondes.
+AMOUNT_THRESHOLD=1000
+VELOCITY_MAX=3
+VELOCITY_WINDOW_SECONDS=60
+ALLOWED_COUNTRIES=FR,DE,ES,IT,BE
+HIGH_RISK_MERCHANT_CATEGORIES=gambling,crypto,jewelry,money_transfer

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -eu
+
+hook_directory="${0%/*}"
+message_file="${1:?commit message file is required}"
+set -- commit-msg "${message_file}"
+. "${hook_directory}/run-pre-commit"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -eu
+
+hook_directory="${0%/*}"
+set -- pre-commit
+. "${hook_directory}/run-pre-commit"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -eu
+
+hook_directory="${0%/*}"
+set -- pre-push
+. "${hook_directory}/run-pre-commit"

--- a/.githooks/run-pre-commit
+++ b/.githooks/run-pre-commit
@@ -1,0 +1,30 @@
+#!/bin/sh
+set -eu
+
+stage="${1:?hook stage is required}"
+shift
+
+repository_root="$(git rev-parse --show-toplevel)"
+export PRE_COMMIT_HOME="${repository_root}/.local/cache/pre-commit"
+
+windows_pre_commit="${repository_root}/.local/tools/pre-commit/Scripts/pre-commit.exe"
+posix_pre_commit="${repository_root}/.local/tools/pre-commit/bin/pre-commit"
+
+if [ -x "${windows_pre_commit}" ]; then
+  pre_commit="${windows_pre_commit}"
+elif [ -x "${posix_pre_commit}" ]; then
+  pre_commit="${posix_pre_commit}"
+else
+  printf '%s\n' \
+    "Project-local pre-commit is missing. Run scripts/dev/bootstrap-hooks.ps1 or scripts/dev/bootstrap-hooks.sh." >&2
+  exit 1
+fi
+
+if [ "${stage}" = "commit-msg" ]; then
+  message_file="${1:?commit message file is required}"
+  exec "${pre_commit}" run \
+    --hook-stage commit-msg \
+    --commit-msg-filename "${message_file}"
+fi
+
+exec "${pre_commit}" run --hook-stage "${stage}"

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# Ownership remains explicit, while human approval is optional on this solo exercise.
+* @ghassenzaouali
+
+# Delivery and security controls remain explicitly visible trust boundaries.
+/.github/ @ghassenzaouali
+/.githooks/ @ghassenzaouali
+/.pre-commit-config.yaml @ghassenzaouali
+/.gitleaks.toml @ghassenzaouali
+/SECURITY.md @ghassenzaouali
+/docs/decisions/ @ghassenzaouali
+/docs/governance/ @ghassenzaouali
+/infra/ @ghassenzaouali
+/scripts/ @ghassenzaouali

--- a/.github/actions/setup-bicep/action.yml
+++ b/.github/actions/setup-bicep/action.yml
@@ -1,0 +1,29 @@
+name: Setup Bicep
+description: Télécharge Bicep Linux épinglé et vérifie son SHA-256 officiel
+
+inputs:
+  version:
+    description: Version Bicep avec préfixe v
+    required: false
+    default: v0.46.1
+  sha256:
+    description: SHA-256 de bicep-linux-x64
+    required: false
+    default: 3e011d629ea4311b7a7dd8f0040ab2b1a072ea4ff5d02cb75e0e55a9a6703fb9
+
+runs:
+  using: composite
+  steps:
+    - name: Télécharger et vérifier Bicep
+      shell: bash
+      env:
+        BICEP_VERSION: ${{ inputs.version }}
+        BICEP_SHA256: ${{ inputs.sha256 }}
+      run: |
+        binary="${RUNNER_TEMP}/bicep"
+        curl --fail --location --silent --show-error \
+          --output "$binary" \
+          "https://github.com/Azure/bicep/releases/download/${BICEP_VERSION}/bicep-linux-x64"
+        echo "${BICEP_SHA256}  ${binary}" | sha256sum --check
+        chmod +x "$binary"
+        echo "BICEP_BIN=$binary" >> "$GITHUB_ENV"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,111 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    target-branch: develop
+    schedule:
+      interval: weekly
+      day: monday
+      time: "05:45"
+      timezone: Europe/Paris
+    open-pull-requests-limit: 3
+    labels:
+      - type:chore
+      - risk:low
+      - area:quality
+      - release:not-required
+    commit-message:
+      prefix: "[TRG-6]"
+
+  - package-ecosystem: npm
+    directory: /api
+    target-branch: develop
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Paris
+    open-pull-requests-limit: 5
+    labels:
+      - type:chore
+      - risk:medium
+      - area:api
+      - area:quality
+      - release:required
+    commit-message:
+      prefix: "[TRG-6]"
+    groups:
+      npm-production:
+        dependency-type: production
+      npm-development:
+        dependency-type: development
+
+  - package-ecosystem: npm
+    directory: /web
+    target-branch: develop
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:15"
+      timezone: Europe/Paris
+    open-pull-requests-limit: 3
+    labels:
+      - type:chore
+      - risk:low
+      - area:web
+      - area:quality
+      - release:not-required
+    commit-message:
+      prefix: "[TRG-6]"
+
+  - package-ecosystem: github-actions
+    directory: /
+    target-branch: develop
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:30"
+      timezone: Europe/Paris
+    open-pull-requests-limit: 3
+    labels:
+      - type:ci
+      - risk:medium
+      - area:quality
+      - release:required
+    commit-message:
+      prefix: "[TRG-8]"
+
+  - package-ecosystem: docker
+    directory: /api
+    target-branch: develop
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:45"
+      timezone: Europe/Paris
+    open-pull-requests-limit: 3
+    labels:
+      - type:ci
+      - risk:high
+      - area:infra
+      - release:required
+    commit-message:
+      prefix: "[TRG-7]"
+
+  - package-ecosystem: docker
+    directory: /web
+    target-branch: develop
+    schedule:
+      interval: weekly
+      day: monday
+      time: "07:00"
+      timezone: Europe/Paris
+    open-pull-requests-limit: 3
+    labels:
+      - type:ci
+      - risk:high
+      - area:infra
+      - release:required
+    commit-message:
+      prefix: "[TRG-7]"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,44 @@
+area:api:
+  - changed-files:
+      - any-glob-to-any-file:
+          - api/**
+
+area:web:
+  - changed-files:
+      - any-glob-to-any-file:
+          - web/**
+
+area:redis:
+  - changed-files:
+      - any-glob-to-any-file:
+          - docker-compose.yml
+          - api/src/**/*redis*
+          - api/src/**/*idempotency*
+          - api/src/**/*velocity*
+
+area:infra:
+  - changed-files:
+      - any-glob-to-any-file:
+          - infra/**
+          - "**/Dockerfile"
+          - docker-compose.yml
+          - .github/workflows/deploy.yml
+          - .github/workflows/load-test.yml
+
+area:quality:
+  - changed-files:
+      - any-glob-to-any-file:
+          - .github/**
+          - .githooks/**
+          - .pre-commit-config.yaml
+          - .gitleaks.toml
+          - scripts/governance/**
+          - sonar-project.properties
+
+area:docs:
+  - changed-files:
+      - any-glob-to-any-file:
+          - README.md
+          - CONTRIBUTING.md
+          - SECURITY.md
+          - docs/**

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,57 @@
+# Pull Request
+
+## Résultat attendu
+
+<!-- Décrire le résultat d’ingénierie ou utilisateur, pas seulement les fichiers. -->
+
+## Travail et périmètre
+
+- Issue : `TRG-N` / `#N`
+- Branche source :
+- Branche cible : `develop`, `release/*` ou `main`
+- Reviewer facultatif :
+- Labels `type`, `risk`, `area`, `release` :
+- Inclus :
+- Explicitement exclu :
+
+## Risques et compatibilité
+
+- Niveau de risque : low / medium / high
+- Impact sécurité ou données sensibles :
+- Impact API, configuration ou infrastructure :
+- Compatibilité et migration :
+- Rollback ou forward-fix :
+
+## Architecture et documentation
+
+- Documents canoniques mis à jour :
+- ADR ajouté ou remplacé :
+- Diagrammes Mermaid mis à jour :
+- Décisions différées :
+
+## Vérification
+
+- Format et lint :
+- Tests unitaires :
+- Tests d’intégration :
+- Couverture :
+- SonarCloud :
+- Snyk / Gitleaks / Trivy :
+- Smoke ou vérification manuelle :
+
+## Checklist
+
+- [ ] La branche, les commits, la PR et l’issue utilisent le même `TRG-N`.
+- [ ] Le titre suit `[TRG-N] résumé commençant par un verbe en minuscule`.
+- [ ] La PR possède exactement un label `type`, `risk`, `release` et au moins un `area`.
+- [ ] Le diff ne contient aucun changement sans rapport, fichier généré ou secret.
+- [ ] Les cas positifs, négatifs, de concurrence et de panne applicables sont testés.
+- [ ] La couverture reste supérieure ou égale à 80 % sans exclusion artificielle.
+- [ ] La documentation et les contrats correspondent au comportement livré.
+- [ ] Tous les contrôles obligatoires sont verts, sans contournement.
+- [ ] Toutes les discussions ouvertes sont résolues.
+- [ ] La stratégie de récupération est explicite.
+
+## Notes pour le reviewer
+
+<!-- Signaler les décisions et preuves les plus importantes à vérifier. -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,70 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - main
+      - "release/**"
+  push:
+    branches:
+      - develop
+      - main
+      - "release/**"
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  governance:
+    name: Gouvernance
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Appliquer les labels de zone
+        if: github.event_name == 'pull_request'
+        uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 # v7.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Récupérer le dépôt
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Installer Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Installer les outils du dépôt
+        run: npm ci --ignore-scripts
+
+      - name: Tester les règles de gouvernance
+        run: node --test scripts/governance/tests/git-policy.test.mjs
+
+      - name: Valider le dépôt
+        run: node scripts/governance/validate-repository.mjs
+
+      - name: Valider la pull request
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/governance/validate-pull-request.mjs
+
+      - name: Installer pre-commit
+        run: python3 -m pip install --disable-pip-version-check pre-commit==4.6.0
+
+      - name: Exécuter les contrôles pre-commit et Gitleaks
+        env:
+          PRE_COMMIT_HOME: ${{ runner.temp }}/pre-commit
+          # Le hook empêche les commits locaux directs. Sur un push déjà fusionné
+          # vers une branche durable, le ruleset GitHub constitue l'autorité.
+          SKIP: no-commit-to-branch
+        run: pre-commit run --all-files --show-diff-on-failure

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,232 @@
+name: Déploiement
+
+on:
+  workflow_call:
+    inputs:
+      stage:
+        description: Environnement GitHub et Azure logique
+        required: true
+        type: string
+      api_image:
+        description: Référence API ACR par digest
+        required: true
+        type: string
+      web_image:
+        description: Référence web ACR par digest
+        required: true
+        type: string
+      source_sha:
+        description: SHA source porté par les images
+        required: true
+        type: string
+      release_version:
+        description: candidate ou version SemVer
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      stage:
+        description: Environnement à restaurer
+        required: true
+        type: choice
+        options:
+          - integration
+          - preproduction
+          - production
+      api_revision:
+        description: Révision API cible, vide pour la précédente
+        required: false
+        type: string
+      web_revision:
+        description: Révision web cible, vide pour la précédente
+        required: false
+        type: string
+
+concurrency:
+  group: deploy-${{ inputs.stage || github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Déployer et smoke tester
+    if: inputs.api_image != '' && inputs.web_image != '' && inputs.source_sha != ''
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    environment:
+      name: ${{ inputs.stage }}
+      url: ${{ steps.target.outputs.url }}
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      STAGE: ${{ inputs.stage }}
+      API_IMAGE: ${{ inputs.api_image }}
+      WEB_IMAGE: ${{ inputs.web_image }}
+      APP_VERSION: ${{ inputs.source_sha }}
+      RELEASE_VERSION: ${{ inputs.release_version }}
+      AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP }}
+      AZURE_CONTAINERAPPS_ENVIRONMENT: ${{ vars.AZURE_CONTAINERAPPS_ENVIRONMENT }}
+      AZURE_CONTAINER_REGISTRY: ${{ vars.AZURE_CONTAINER_REGISTRY }}
+      AZURE_API_APP_NAME: ${{ vars.AZURE_API_APP_NAME }}
+      AZURE_WEB_APP_NAME: ${{ vars.AZURE_WEB_APP_NAME }}
+      AZURE_REDIS_APP_NAME: ${{ vars.AZURE_REDIS_APP_NAME }}
+    steps:
+      - name: Récupérer le dépôt
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Installer Bicep épinglé
+        uses: ./.github/actions/setup-bicep
+
+      - name: Compiler le template applicatif exact
+        run: |
+          "$BICEP_BIN" build infra/apps.bicep --outfile "${RUNNER_TEMP}/apps.json"
+
+      - name: S’authentifier à Azure par OIDC
+        uses: Azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c # v3.0.2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Capturer les révisions servant au rollback
+        id: previous
+        shell: bash
+        run: |
+          case "$STAGE" in
+            integration|preproduction) suffix="-$STAGE" ;;
+            production) suffix='' ;;
+            *) echo "STAGE invalide" >&2; exit 1 ;;
+          esac
+          api_app="${AZURE_API_APP_NAME:-api}${suffix}"
+          web_app="${AZURE_WEB_APP_NAME:-web}${suffix}"
+          current_revision() {
+            az containerapp revision list --all --resource-group "$AZURE_RESOURCE_GROUP" --name "$1" \
+              --query 'sort_by([?properties.active],&properties.createdTime)[-1].name' --output tsv 2>/dev/null || true
+          }
+          echo "api_revision=$(current_revision "$api_app")" >> "$GITHUB_OUTPUT"
+          echo "web_revision=$(current_revision "$web_app")" >> "$GITHUB_OUTPUT"
+
+      - name: Déployer les digests sans reconstruction
+        shell: bash
+        env:
+          API_KEY: ${{ secrets.API_KEY }}
+          REDIS_HMAC_SECRET: ${{ secrets.REDIS_HMAC_SECRET }}
+          REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD }}
+          # Un secret d'environnement absent peut retomber sur le secret du dépôt.
+          # La production reçoit donc explicitement une valeur vide.
+          LOAD_TEST_TOKEN: ${{ inputs.stage != 'production' && secrets.LOAD_TEST_TOKEN || '' }}
+          APPS_TEMPLATE_FILE: ${{ runner.temp }}/apps.json
+          DEPLOY_MODE: apply
+        run: bash infra/deploy-apps.sh
+
+      - name: Résoudre l’URL publique
+        id: target
+        shell: bash
+        run: |
+          case "$STAGE" in
+            integration|preproduction) suffix="-$STAGE" ;;
+            production) suffix='' ;;
+          esac
+          web_app="${AZURE_WEB_APP_NAME:-web}${suffix}"
+          fqdn="$(az containerapp show --resource-group "$AZURE_RESOURCE_GROUP" --name "$web_app" --query properties.configuration.ingress.fqdn --output tsv)"
+          test -n "$fqdn"
+          echo "url=https://$fqdn" >> "$GITHUB_OUTPUT"
+
+      - name: Smoke test avec rollback automatique
+        shell: bash
+        env:
+          PUBLIC_BASE_URL: ${{ steps.target.outputs.url }}
+          API_REVISION: ${{ steps.previous.outputs.api_revision }}
+          WEB_REVISION: ${{ steps.previous.outputs.web_revision }}
+        run: |
+          if node scripts/smoke/smoke-test.mjs; then
+            exit 0
+          fi
+
+          echo "Smoke rouge : tentative de rollback des révisions précédentes." >&2
+          if [ -z "$API_REVISION" ] || [ -z "$WEB_REVISION" ]; then
+            echo "Premier déploiement : aucune révision antérieure disponible." >&2
+            exit 1
+          fi
+          bash infra/rollback.sh
+          node scripts/smoke/smoke-test.mjs
+          echo "Rollback sain après échec du candidat ; le workflow reste rouge." >&2
+          exit 1
+
+      - name: Enregistrer la preuve de déploiement
+        id: evidence
+        shell: bash
+        env:
+          PUBLIC_BASE_URL: ${{ steps.target.outputs.url }}
+        run: |
+          jq -n \
+            --arg stage "$STAGE" \
+            --arg sourceSha "$APP_VERSION" \
+            --arg releaseVersion "$RELEASE_VERSION" \
+            --arg apiImage "$API_IMAGE" \
+            --arg webImage "$WEB_IMAGE" \
+            --arg publicBaseUrl "$PUBLIC_BASE_URL" \
+            --arg deployedAt "$(date --utc +%FT%TZ)" \
+            '{stage:$stage,sourceSha:$sourceSha,releaseVersion:$releaseVersion,apiImage:$apiImage,webImage:$webImage,publicBaseUrl:$publicBaseUrl,deployedAt:$deployedAt,smoke:"passed"}' \
+            > deployment-evidence.json
+          {
+            echo "### Déploiement $STAGE"
+            echo "- Source : $APP_VERSION"
+            echo "- API : $API_IMAGE"
+            echo "- Web : $WEB_IMAGE"
+            echo "- URL : $PUBLIC_BASE_URL"
+            echo "- Smoke : passed"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Conserver la preuve immuable
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: deployment-${{ inputs.stage }}-${{ inputs.source_sha }}
+          path: deployment-evidence.json
+          if-no-files-found: error
+          retention-days: 30
+
+  rollback:
+    name: Rollback contrôlé
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    environment:
+      name: ${{ inputs.stage }}
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      STAGE: ${{ inputs.stage }}
+      API_REVISION: ${{ inputs.api_revision }}
+      WEB_REVISION: ${{ inputs.web_revision }}
+      AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP }}
+      AZURE_API_APP_NAME: ${{ vars.AZURE_API_APP_NAME }}
+      AZURE_WEB_APP_NAME: ${{ vars.AZURE_WEB_APP_NAME }}
+    steps:
+      - name: Récupérer le dépôt
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: S’authentifier à Azure par OIDC
+        uses: Azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c # v3.0.2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Rebasculer le trafic
+        run: bash infra/rollback.sh
+
+      - name: Vérifier la révision restaurée
+        shell: bash
+        run: |
+          case "$STAGE" in
+            integration|preproduction) suffix="-$STAGE" ;;
+            production) suffix='' ;;
+          esac
+          web_app="${AZURE_WEB_APP_NAME:-web}${suffix}"
+          fqdn="$(az containerapp show --resource-group "$AZURE_RESOURCE_GROUP" --name "$web_app" --query properties.configuration.ingress.fqdn --output tsv)"
+          PUBLIC_BASE_URL="https://$fqdn" node scripts/smoke/smoke-test.mjs

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -1,0 +1,104 @@
+name: Tests de charge
+
+on:
+  workflow_dispatch:
+    inputs:
+      stage:
+        description: Environnement hors production à tester
+        required: true
+        type: choice
+        options:
+          - integration
+          - preproduction
+      profile:
+        description: Profil k6
+        required: true
+        type: choice
+        options:
+          - baseline
+          - scale
+          - stress
+
+concurrency:
+  group: load-${{ inputs.stage }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  load:
+    name: k6 ${{ inputs.profile }} sur ${{ inputs.stage }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    environment:
+      name: ${{ inputs.stage }}
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      STAGE: ${{ inputs.stage }}
+      LOAD_PROFILE: ${{ inputs.profile }}
+      LOAD_TEST_TOKEN: ${{ secrets.LOAD_TEST_TOKEN }}
+      AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP }}
+      AZURE_WEB_APP_NAME: ${{ vars.AZURE_WEB_APP_NAME }}
+    steps:
+      - name: Récupérer le dépôt
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Installer Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+
+      - name: Installer k6 épinglé
+        uses: grafana/setup-k6-action@db07bd9765aac508ef18982e52ab937fe633a065 # v1.2.1
+        with:
+          k6-version: 2.2.0
+
+      - name: S’authentifier à Azure par OIDC
+        uses: Azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c # v3.0.2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Résoudre la cible hors production
+        id: target
+        shell: bash
+        run: |
+          test "$STAGE" = "integration" -o "$STAGE" = "preproduction"
+          test -n "$LOAD_TEST_TOKEN"
+          web_app="${AZURE_WEB_APP_NAME:-web}-${STAGE}"
+          fqdn="$(az containerapp show --resource-group "$AZURE_RESOURCE_GROUP" --name "$web_app" --query properties.configuration.ingress.fqdn --output tsv)"
+          test -n "$fqdn"
+          echo "url=https://$fqdn" >> "$GITHUB_OUTPUT"
+
+      - name: Exécuter le profil et conserver la sortie brute
+        shell: bash
+        env:
+          PUBLIC_BASE_URL: ${{ steps.target.outputs.url }}
+          K6_SUMMARY_PATH: artifacts/k6-summary.json
+        run: |
+          mkdir -p artifacts
+          set -o pipefail
+          k6 run scripts/load/load-test.js 2>&1 | tee artifacts/k6.log
+
+      - name: Construire la preuve exploitable
+        shell: bash
+        run: |
+          node scripts/load/evidence.mjs artifacts/k6.log artifacts/k6-summary.json artifacts/load-evidence.json "$LOAD_PROFILE"
+          {
+            echo "### Charge $LOAD_PROFILE sur $STAGE"
+            echo '```json'
+            cat artifacts/load-evidence.json
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Publier les preuves k6
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: k6-${{ inputs.stage }}-${{ inputs.profile }}-${{ github.run_id }}
+          path: artifacts/
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    name: Publier la GitHub Release
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    steps:
+      - name: Récupérer le tag
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Vérifier version, source et digests
+        env:
+          AZURE_CONTAINER_REGISTRY: ${{ vars.AZURE_CONTAINER_REGISTRY }}
+        run: |
+          node scripts/release/manifest.mjs .release/manifest.json
+          test "${{ github.ref_name }}" = "$(node -p "require('./.release/manifest.json').version")"
+
+      - name: Créer une release traçable
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          api_image="$(node -p "require('./.release/manifest.json').apiImage")"
+          web_image="$(node -p "require('./.release/manifest.json').webImage")"
+          source_sha="$(node -p "require('./.release/manifest.json').sourceSha")"
+          notes="$(printf 'Source validée : %s\n\nAPI : %s\n\nWeb : %s\n\nLes limites et la procédure de rollback sont documentées dans le dépôt.' "$source_sha" "$api_image" "$web_image")"
+          gh release create "$GITHUB_REF_NAME" --verify-tag --title "Transaction Risk Gate $GITHUB_REF_NAME" \
+            --notes "$notes"

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,10 @@
+title = "Transaction Risk Gate Gitleaks policy"
+
+[extend]
+useDefault = true
+
+[[allowlists]]
+description = "SonarCloud connected-mode project identity is public configuration"
+condition = "AND"
+paths = ['''^\.vscode/settings\.json$''', '''^\.sonarlint/connectedMode\.json$''']
+regexes = ['''^ghassenzaouali$''', '''^ghassenzaouali_transaction-risk-gate$''']

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,11 @@
+{
+  "config": {
+    "default": true,
+    "MD013": false,
+    "MD024": {
+      "siblings_only": true,
+    },
+  },
+  "globs": ["README.md", "CONTRIBUTING.md", "SECURITY.md", "docs/**/*.md", ".github/**/*.md"],
+  "ignores": [".local/**", "artifacts/**", "coverage/**", "node_modules/**"],
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,99 @@
+default_install_hook_types:
+  - pre-commit
+  - commit-msg
+  - pre-push
+
+default_stages:
+  - pre-commit
+
+fail_fast: false
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: check-added-large-files
+        args:
+          - --maxkb=512
+      - id: check-case-conflict
+      - id: check-json
+      - id: check-merge-conflict
+      - id: check-yaml
+      - id: detect-private-key
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+        args:
+          - --fix=lf
+        exclude: '\.(bat|cmd)$'
+      - id: no-commit-to-branch
+        args:
+          - --branch
+          - main
+          - --branch
+          - develop
+      - id: trailing-whitespace
+        args:
+          - --markdown-linebreak-ext=md
+
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks-docker
+        entry: >-
+          ghcr.io/gitleaks/gitleaks@sha256:c00b6bd0aeb3071cbcb79009cb16a60dd9e0a7c60e2be9ab65d25e6bc8abbb7f
+          git --pre-commit --redact --staged --verbose
+        args:
+          - --config=.gitleaks.toml
+
+  - repo: local
+    hooks:
+      - id: trg-format
+        name: Transaction Risk Gate format
+        entry: npx --no-install prettier --check --ignore-unknown
+        language: system
+        types_or:
+          - javascript
+          - json
+          - markdown
+          - ts
+          - yaml
+      - id: trg-markdown
+        name: Transaction Risk Gate Markdown
+        entry: npx --no-install markdownlint-cli2
+        language: system
+        files: '\.md$'
+        pass_filenames: false
+      - id: trg-repository-policy
+        name: Transaction Risk Gate repository policy
+        entry: node scripts/governance/validate-repository.mjs
+        language: system
+        pass_filenames: false
+      - id: trg-governance-tests
+        name: Transaction Risk Gate governance tests
+        entry: node --test scripts/governance/tests/git-policy.test.mjs
+        language: system
+        files: '(^|/)(scripts/governance/.+|\.github/.+|\.githooks/.+|\.pre-commit-config\.yaml)$'
+        pass_filenames: false
+      - id: trg-operations-tests
+        name: Transaction Risk Gate operations tests
+        entry: >-
+          node --test scripts/smoke/smoke-test.test.mjs scripts/release/manifest.test.mjs
+          scripts/load/config.test.mjs scripts/load/evidence.test.mjs
+          scripts/failure/redis-outage.test.mjs
+        language: system
+        files: '(^|/)(scripts/(smoke|release|load|failure)/.+|infra/rollback\.sh|\.release/.+)$'
+        pass_filenames: false
+      - id: trg-commit-message
+        name: Transaction Risk Gate commit message
+        entry: node scripts/governance/validate-commit-message.mjs
+        language: system
+        stages:
+          - commit-msg
+      - id: trg-pre-push
+        name: Transaction Risk Gate pre-push policy
+        entry: node scripts/governance/validate-pre-push.mjs
+        language: system
+        always_run: true
+        pass_filenames: false
+        stages:
+          - pre-push

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,8 @@
+.git/
+.local/
+.scannerwork/
+artifacts/
+coverage/
+dist/
+node_modules/
+**/package-lock.json

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,10 @@
+{
+  "arrowParens": "always",
+  "endOfLine": "lf",
+  "printWidth": 100,
+  "proseWrap": "always",
+  "semi": true,
+  "singleQuote": false,
+  "tabWidth": 2,
+  "trailingComma": "all"
+}

--- a/.release/README.md
+++ b/.release/README.md
@@ -1,0 +1,8 @@
+# Manifeste de promotion
+
+`manifest.json` est créé sur `release/vX.Y.Z` à partir des digests déjà publiés et validés en
+intégration. Les pipelines de préproduction et production lisent ce fichier et refusent tout tag
+mutable. Le fichier d’exemple ne constitue pas une preuve de déploiement.
+
+Le manifeste réel contient uniquement la version, le SHA source, les deux références ACR par digest
+et la date de création. Aucun secret, URL signée ou résultat généré volumineux n’y entre.

--- a/.release/manifest.example.json
+++ b/.release/manifest.example.json
@@ -1,0 +1,7 @@
+{
+  "version": "v1.0.0",
+  "sourceSha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "apiImage": "registry.azurecr.io/trg-api@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "webImage": "registry.azurecr.io/trg-web@sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  "createdAt": "2026-09-01T00:00:00.000Z"
+}

--- a/.sonarlint/connectedMode.json
+++ b/.sonarlint/connectedMode.json
@@ -1,0 +1,4 @@
+{
+  "sonarCloudOrganization": "ghassenzaouali",
+  "projectKey": "ghassenzaouali_transaction-risk-gate"
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,9 @@
+{
+  "recommendations": [
+    "davidanson.vscode-markdownlint",
+    "esbenp.prettier-vscode",
+    "redhat.vscode-yaml",
+    "sonarsource.sonarlint-vscode",
+    "snyk-security.snyk-vulnerability-scanner"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,15 @@
+{
+  "editor.codeActionsOnSave": {
+    "source.fixAll": "explicit"
+  },
+  "editor.formatOnSave": true,
+  "files.eol": "\n",
+  "files.insertFinalNewline": true,
+  "files.trimTrailingWhitespace": true,
+  "markdownlint.run": "onSave",
+  "prettier.requireConfig": true,
+  "sonarlint.connectedMode.project": {
+    "connectionId": "ghassenzaouali",
+    "projectKey": "ghassenzaouali_transaction-risk-gate"
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Journal des versions
+
+Les changements notables suivent [Semantic Versioning](https://semver.org/lang/fr/). Les images
+promues sont identifiées dans le manifeste de release et ne sont jamais reconstruites entre les
+environnements.
+
+<!-- À COMPLÉTER en phase release : date réelle et périmètre exact livré. -->
+
+## v1.0.0 — AAAA-MM-JJ
+
+Première version de Transaction Risk Gate :
+
+- moteur explicable à cinq règles et décisions `APPROVED`, `REVIEW` ou `REJECTED` ;
+- vélocité et idempotence distribuées dans Redis, avec politique fail-safe en cas de panne ;
+- API Fastify privée et interface Nginx publique, toutes deux exécutées sans privilège root ;
+- logs JSON, métriques Prometheus, health, readiness et arrêt gracieux ;
+- couverture supérieure à 80 %, cible métier supérieure à 90 % et quality gates bloquants ;
+- SonarCloud, Snyk, Gitleaks, Trivy, hooks locaux et gouvernance Git automatisée ;
+- images immuables, déploiement Azure Container Apps par OIDC, smoke test et rollback ;
+- profils k6 `baseline`, `scale` et `stress` avec cohérence Redis observée sous autoscaling ;
+- contrat OpenAPI, collection Postman et documentation française complète.
+
+Limites assumées : règles heuristiques, EUR uniquement, aucune authentification utilisateur ni
+persistance métier durable, Redis mono-replica et plateforme Azure mutualisée.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,69 @@
+# Contribuer à Transaction Risk Gate
+
+Toute contribution passe par une issue `TRG-N`, une branche courte et une pull request validée par
+les contrôles automatiques. La politique canonique se trouve dans le
+[guide Git](docs/governance/git-policy.md).
+
+## Préparer le poste
+
+Prérequis : Git, Node.js 22 ou plus récent, npm, Python 3.11 ou plus récent et Docker.
+
+Sous PowerShell :
+
+```powershell
+./scripts/dev/bootstrap-hooks.ps1
+npm ci --prefix api
+```
+
+Sous Linux ou Git Bash :
+
+```bash
+./scripts/dev/bootstrap-hooks.sh
+npm ci --prefix api
+```
+
+Le bootstrap installe une version locale et épinglée de `pre-commit`, prépare ses environnements et
+configure `core.hooksPath=.githooks`. Aucun outil Python n’est installé globalement.
+
+## Cycle d’une contribution
+
+1. Choisir une issue et synchroniser `develop`.
+2. Créer `<classe>/TRG-<numéro>-<description-kebab-case>`.
+3. Modifier ensemble code, tests, contrats et documentation concernés.
+4. Exécuter les contrôles locaux puis relire `git diff`.
+5. Créer des commits `[TRG-N] verbe à l’infinitif`.
+6. Pousser vers une branche distante de même nom.
+7. Ouvrir une PR vers `develop`, résoudre les discussions et attendre les checks obligatoires.
+
+Exemple :
+
+```powershell
+git fetch origin
+git checkout develop
+git pull --ff-only origin develop
+git checkout -b feat/TRG-2-risk-engine
+```
+
+Les branches sources sont conservées après fusion pour cet exercice. Les pushes directs et les
+force-pushes vers les références protégées sont interdits.
+
+## Vérification locale
+
+Contrôles rapides :
+
+```powershell
+node --test scripts/governance/tests/git-policy.test.mjs
+node scripts/governance/validate-repository.mjs
+npm run build --prefix api
+npm test --prefix api
+npm test --prefix web
+```
+
+La CI répète ces contrôles dans un environnement propre et reste l’autorité. Un hook contourné pour
+diagnostiquer le poste ne constitue jamais une preuve de qualité et doit être signalé dans la PR.
+
+## Documentation
+
+La documentation évolue dans la même PR que le comportement. Mermaid reste la source des diagrammes
+et OpenAPI deviendra la source du contrat HTTP. Le README complet sera finalisé lorsque le produit
+et ses preuves opérationnelles seront stables.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,162 @@
 # Transaction Risk Gate
 
-Passerelle de décision de risque transactionnel : une API reçoit une transaction et rend une
-décision explicable — `APPROVED`, `REVIEW` ou `REJECTED` — avec les règles qui l'ont motivée.
+[![CI](https://github.com/ghassenzaouali/transaction-risk-gate/actions/workflows/ci.yml/badge.svg?branch=develop)](https://github.com/ghassenzaouali/transaction-risk-gate/actions/workflows/ci.yml)
+[![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=ghassenzaouali_transaction-risk-gate&metric=alert_status)](https://sonarcloud.io/dashboard?id=ghassenzaouali_transaction-risk-gate)
 
-Dépôt en cours d'initialisation.
+Application de démonstration qui attribue à une transaction synthétique une décision explicable :
+`APPROVED`, `REVIEW` ou `REJECTED`. Le périmètre est volontairement petit ; l’objectif principal est
+de démontrer comment concevoir, tester, sécuriser, livrer et exploiter un service cloud.
+
+## État vérifié
+
+<!-- À COMPLÉTER en TRG-9 : renseigner la couverture réelle mesurée, la version taguée et les URLs
+     publiques de ce dépôt une fois les trois environnements déployés. -->
+
+| Élément                   | État                                                         |
+| ------------------------- | ------------------------------------------------------------ |
+| Domaine et API            | implémentés et testés                                        |
+| Couverture                | API ≥ 80 %, domaine ≥ 90 %, web ≥ 80 % en lignes (cibles CI) |
+| SonarCloud, Snyk et Trivy | bloquants sur toute PR vers une branche durable              |
+| Images Docker et Compose  | images non-root, smoke local                                 |
+| Déploiement Azure         | OIDC, ACR et trois environnements                            |
+| URL publique              | «`PUBLIC_BASE_URL`»                                          |
+| Charge et panne           | profils k6 baseline/scale/stress et runbook panne Redis      |
+
+Les résultats réels sont consignés dans [les tests de charge](docs/test-charge.md),
+[les scénarios de panne](docs/test-panne.md) et [les preuves de livraison](docs/livraison.md).
+
+Production : «URL publique — à renseigner après le premier déploiement `main`».
+
+Intégration : «URL publique — à renseigner après le premier déploiement `develop`».
+
+## Architecture
+
+```mermaid
+flowchart LR
+    User[Utilisateur] -->|HTTPS| Web[Web public\nNginx + interface légère]
+    Web -->|secret interservice| Api[API Fastify\n1 à 10 replicas]
+    Api -->|vélocité, idempotence, rate limit| Redis[(Redis privé)]
+    Api --> Obs[Logs JSON et métriques]
+    GitHub[GitHub Actions] -->|OIDC| Azure[Azure Container Apps]
+    GitHub -->|images par digest| ACR[Azure Container Registry]
+    ACR --> Azure
+```
+
+Le navigateur ne reçoit jamais `API_KEY`. Nginx l’injecte vers l’API interne. Redis fournit l’état
+partagé nécessaire aux replicas. S’il est indisponible, aucune transaction ne peut être approuvée :
+le service force `REVIEW`, `degraded: true` et rend l’incident observable.
+
+La [documentation d’architecture](docs/architecture.md), les [ADR](docs/decisions/) et le
+[modèle métier](docs/metier.md) expliquent les décisions et leurs compromis.
+
+## Démarrage local
+
+Prérequis : Git, Docker Desktop avec Compose, Node.js 22 ou plus récent pour les outils locaux.
+
+```powershell
+Copy-Item .env.example .env
+docker compose up --build --detach
+```
+
+Ouvrir <http://localhost:8080>. Vérifier ensuite :
+
+```powershell
+Invoke-WebRequest http://localhost:8080/healthz
+Invoke-RestMethod http://localhost:8080/ready
+Invoke-RestMethod http://localhost:8080/api/rules
+```
+
+Arrêt récupérable :
+
+```powershell
+docker compose down
+```
+
+Les valeurs de `.env.example` servent uniquement au développement local. `.env` est ignoré par Git.
+
+## API et démonstration
+
+- contrat de référence : [OpenAPI 3.1](docs/api/openapi.yaml) ;
+- démonstration : [collection Postman](docs/postman/transaction-risk-gate.postman_collection.json) ;
+- environnements Postman : [local](docs/postman/local.postman_environment.json) et
+  [cloud](docs/postman/cloud.postman_environment.json) ;
+- interface : scénarios APPROVED, REVIEW et REJECTED, règles actives et replicas observés.
+
+Les routes métier sont `POST /api/decisions` et `GET /api/rules`. `GET /health`, `GET /ready` et
+`GET /metrics` servent au cycle de vie et à la supervision de l’API interne.
+
+## Qualité et sécurité
+
+```powershell
+npm ci
+npm --prefix api ci
+npm --prefix web ci
+npm run format:check
+npm run docs:lint
+npm run governance:test
+npm run operations:test
+npm --prefix api run build
+npm --prefix api run test:coverage
+npm --prefix api run test:coverage:domain
+npm --prefix web run test:coverage
+pre-commit run --all-files
+```
+
+La CI refuse le merge si format, TypeScript strict, tests, couverture minimale de 80 %, cible métier
+de 90 %, Gitleaks, SonarCloud, Snyk, construction Docker ou Trivy échouent. Les actions GitHub et
+images de base sont épinglées, les permissions sont minimales et aucun contrôle obligatoire n’est
+toléré en échec.
+
+Voir [stratégie de tests](docs/tests.md), [sécurité](docs/securite.md) et
+[quality gates](docs/governance/quality-security-gates.md).
+
+## Charge, résilience et exploitation
+
+Le workflow manuel **Tests de charge** cible uniquement `integration` ou `preproduction` :
+
+- `baseline` : cinq utilisateurs virtuels pendant 30 secondes ;
+- `scale` : montée progressive jusqu’à 150 utilisateurs ;
+- `stress` : montée jusqu’à 300 utilisateurs pour rechercher la limite.
+
+Chaque profil exige erreurs `< 1 %` et checks `> 99 %`. Les budgets p95/p99 sont respectivement
+`250/500 ms` pour `baseline`, `750/1000 ms` pour `scale` et `1250/1750 ms` pour `stress`. Les deux
+derniers exigent au moins deux `X-Instance-Id` et vérifient que la vélocité partagée se déclenche
+malgré la distribution des requêtes.
+
+Le scénario local de panne Redis est reproductible :
+
+```powershell
+node scripts/failure/redis-outage.mjs
+```
+
+Il arrête Redis, exige une décision fail-safe, redémarre Redis et attend le retour au mode normal.
+L’exploitation, les métriques, alertes et requêtes Log Analytics sont détaillées dans
+[le guide d’exploitation](docs/exploitation.md).
+
+## Livraison et Git
+
+Le flux exercé est :
+
+```text
+feat|fix|security|test|docs|ci/TRG-N-* -> develop -> release/vX.Y.Z -> main -> tag vX.Y.Z
+```
+
+Chaque étape utilise une PR, des labels `type`, `risk`, `area` et `release`, des branches protégées
+et des checks obligatoires. `develop` construit puis publie une fois les images validées. Les
+branches `release/*` et `main` promeuvent exactement les mêmes digests vers préproduction puis
+production. Le smoke test déclenche un rollback contrôlé en cas d’échec.
+
+Voir [politique Git](docs/governance/git-policy.md),
+[politique de release](docs/governance/release-policy.md) et
+[livraison/rollback](docs/livraison.md).
+
+## Limites et usage de l’IA
+
+Ce projet n’est pas un système antifraude réel : règles heuristiques, EUR uniquement, aucune
+authentification utilisateur et aucune conservation durable des décisions. Les limites complètes et
+leurs conséquences figurent dans [limites](docs/limites.md).
+
+L’IA a été autorisée pour cet exercice et utilisée comme partenaire d’implémentation, de revue et de
+documentation. Les choix ont été discutés, chaque changement reste traçable dans Git et aucune
+sortie n’est acceptée sans tests, quality gates et vérification humaine. L’usage de l’IA ne remplace
+ni la responsabilité de l’auteur, ni la revue, ni les preuves d’exécution.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Politique de sécurité
+
+## Signaler un problème
+
+Ne publiez pas une vulnérabilité, une clé ou une donnée bancaire dans une issue publique. Prévenez
+directement les propriétaires du dépôt par un canal privé et indiquez uniquement :
+
+- le composant et la version concernés ;
+- les préconditions et l’impact supposé ;
+- une reproduction utilisant des données synthétiques ;
+- une proposition de correction ou de confinement si elle existe.
+
+Les secrets éventuellement exposés sont révoqués avant l’analyse détaillée. Un rapport public
+expurgé peut être ajouté après correction.
+
+## Données protégées
+
+Le projet n’accepte aucune véritable donnée bancaire. Les identifiants de carte des tests sont
+synthétiques. Les journaux, traces, métriques, rapports et clés Redis ne doivent contenir ni
+identifiant brut, ni secret, ni payload complet.
+
+## Politique de vulnérabilité
+
+- toute vulnérabilité `CRITICAL` bloque la fusion et la release ;
+- toute vulnérabilité `HIGH` exploitable bloque la fusion et la release ;
+- un report exceptionnel précise propriétaire, justification, compensation et date d’expiration ;
+- un scanner indisponible ou non configuré fait échouer un contrôle obligatoire ;
+- une correction publiée produit une nouvelle version, jamais la modification d’un tag ou d’une
+  image existante.
+
+Les contrôles applicables sont détaillés dans la
+[politique qualité et sécurité](docs/governance/quality-security-gates.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,40 @@
+# Documentation
+
+Cette documentation décrit le comportement livré, les preuves exécutées et les limites. Une preuve
+cloud n’est déclarée acquise qu’après un workflow vert associé à un SHA.
+
+## Architecture et décisions
+
+- [Architecture générale](architecture.md)
+- [Modèle métier et règles de décision](metier.md)
+- [Résilience et cohérence Redis](redis.md)
+- [Sécurité de l'API](securite.md)
+- [Exploitation et observabilité](exploitation.md)
+- [Plateforme conteneurisée et Azure](plateforme-azure.md)
+- [Livraison, promotion et rollback](livraison.md)
+- [Interface web de démonstration](interface-web.md)
+- [Contrat OpenAPI](api/openapi.yaml)
+- [Collection Postman](postman/transaction-risk-gate.postman_collection.json)
+- [Stratégie de tests](tests.md)
+- [Tests de charge](test-charge.md)
+- [Tests de panne](test-panne.md)
+- [Limites et améliorations](limites.md)
+- [ADR-001 — TypeScript et Fastify](decisions/ADR-001-typescript-fastify.md)
+- [ADR-002 — Cohérence distribuée avec Redis](decisions/ADR-002-coherence-redis.md)
+- [ADR-003 — Hébergement Azure](decisions/ADR-003-hebergement-azure.md)
+
+## Gouvernance
+
+- [Politique Git](governance/git-policy.md)
+- [Definition of Done](governance/definition-of-done.md)
+- [Quality gates](governance/quality-security-gates.md)
+- [Politique de release](governance/release-policy.md)
+
+## Preuves attendues
+
+<!-- À COMPLÉTER en TRG-9, une fois les workflows verts et associés à un SHA. -->
+
+- déploiements Azure par OIDC et smoke tests d’intégration, préproduction et production ;
+- mesures k6 baseline, scale et stress avec zéro erreur HTTP ;
+- panne Redis Compose, rollback Azure d’intégration et restauration ;
+- promotion du même digest jusqu’à la release taguée.

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1,0 +1,358 @@
+openapi: 3.1.0
+info:
+  title: Transaction Risk Gate API
+  version: 1.0.0
+  description: >-
+    Contrat de l'API interne de décision. Le web public relaie /api/* et /ready, puis injecte
+    X-API-Key côté serveur. Les données sont synthétiques et la v1 accepte uniquement EUR.
+servers:
+  - url: http://localhost:3000
+    description: API lancée directement en local
+tags:
+  - name: Decision
+  - name: Policy
+  - name: Operations
+paths:
+  /api/decisions:
+    post:
+      tags: [Decision]
+      summary: Évaluer une transaction synthétique
+      operationId: evaluateTransaction
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - $ref: "#/components/parameters/IdempotencyKey"
+        - $ref: "#/components/parameters/RequestId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Transaction"
+      responses:
+        "200":
+          description: Décision normale ou fail-safe
+          headers:
+            X-Instance-Id:
+              $ref: "#/components/headers/InstanceId"
+            X-Request-Id:
+              $ref: "#/components/headers/RequestId"
+            X-Degraded-Mode:
+              description: Présent avec true uniquement lorsque Redis est indisponible.
+              schema:
+                type: string
+                const: "true"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DecisionResponse"
+        "400":
+          description: Transaction, idempotence, request id ou query invalide
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Secret interservice absent ou invalide
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "409":
+          description: Idempotency-Key déjà associée à un autre payload
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "413":
+          description: Payload supérieur à la limite configurée
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "415":
+          description: Content-Type différent de application/json
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Limite de requêtes dépassée
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/rules:
+    get:
+      tags: [Policy]
+      summary: Lire la politique de risque active
+      operationId: getRules
+      security:
+        - ApiKeyAuth: []
+      responses:
+        "200":
+          description: Cinq règles dont les poids totalisent 100
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RulesResponse"
+        "401":
+          description: Secret interservice absent ou invalide
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /health:
+    get:
+      tags: [Operations]
+      summary: Vérifier la liveness du processus API
+      operationId: health
+      responses:
+        "200":
+          description: Processus vivant
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+                required: [status]
+                properties:
+                  status:
+                    type: string
+                    const: ok
+  /ready:
+    get:
+      tags: [Operations]
+      summary: Lire la readiness et le mode Redis
+      operationId: readiness
+      responses:
+        "200":
+          description: Service disponible en mode normal ou fail-safe
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Readiness"
+        "503":
+          description: Arrêt gracieux en cours
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+                required: [status]
+                properties:
+                  status:
+                    type: string
+                    const: shutting_down
+  /metrics:
+    get:
+      tags: [Operations]
+      summary: Exposer les métriques Prometheus sur le réseau privé
+      operationId: metrics
+      responses:
+        "200":
+          description: Exposition Prometheus
+          content:
+            text/plain:
+              schema:
+                type: string
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Key
+      description: Secret interservice injecté par Nginx, jamais livré au navigateur.
+  parameters:
+    IdempotencyKey:
+      name: Idempotency-Key
+      in: header
+      required: false
+      description: 8 à 128 caractères sûrs ; même clé et même payload rejouent la réponse.
+      schema:
+        type: string
+        minLength: 8
+        maxLength: 128
+        pattern: "^[A-Za-z0-9._:-]+$"
+    RequestId:
+      name: X-Request-Id
+      in: header
+      required: false
+      description: Corrélation facultative, remplacée par un UUID si absente.
+      schema:
+        type: string
+        minLength: 1
+        maxLength: 64
+        pattern: "^[A-Za-z0-9][A-Za-z0-9._:-]{0,63}$"
+  headers:
+    InstanceId:
+      description: Identifiant du replica API ayant traité la requête.
+      schema:
+        type: string
+    RequestId:
+      description: Identifiant de corrélation accepté ou généré.
+      schema:
+        type: string
+  schemas:
+    Transaction:
+      type: object
+      additionalProperties: false
+      required: [transactionId, cardId, amount, currency, country, channel, merchantCategory]
+      properties:
+        transactionId:
+          type: string
+          minLength: 1
+          maxLength: 64
+          examples: [txn-demo-001]
+        cardId:
+          type: string
+          minLength: 1
+          maxLength: 128
+          examples: [card-synthetic-001]
+        amount:
+          type: number
+          exclusiveMinimum: 0
+          maximum: 1000000000
+          examples: [125.5]
+        currency:
+          type: string
+          const: EUR
+        country:
+          type: string
+          pattern: "^[A-Za-z]{2}$"
+          examples: [FR]
+        channel:
+          type: string
+          enum: [online, in_store]
+        merchantCategory:
+          type: string
+          minLength: 1
+          maxLength: 64
+          pattern: "^[A-Za-z][A-Za-z0-9_]*$"
+          examples: [grocery]
+    Reason:
+      type: object
+      additionalProperties: false
+      required: [rule, weight, detail]
+      properties:
+        rule:
+          type: string
+          enum:
+            - VELOCITY
+            - COUNTRY_RISK
+            - AMOUNT_THRESHOLD
+            - HIGH_RISK_MERCHANT
+            - CARD_NOT_PRESENT
+            - RISK_CONTEXT_UNAVAILABLE
+        weight:
+          type: integer
+          minimum: 0
+          maximum: 30
+        detail:
+          type: string
+    DecisionResponse:
+      type: object
+      additionalProperties: false
+      required: [decisionId, decision, score, reasons, evaluatedAt, degraded]
+      properties:
+        decisionId:
+          type: string
+          pattern: "^dec_[0-9a-f-]+$"
+        decision:
+          type: string
+          enum: [APPROVED, REVIEW, REJECTED]
+        score:
+          type: integer
+          minimum: 0
+          maximum: 100
+        reasons:
+          type: array
+          items:
+            $ref: "#/components/schemas/Reason"
+        evaluatedAt:
+          type: string
+          format: date-time
+        degraded:
+          type: boolean
+    RulesResponse:
+      type: object
+      additionalProperties: false
+      required: [currency, maxScore, scoreBands, rules]
+      properties:
+        currency:
+          type: string
+          const: EUR
+        maxScore:
+          type: integer
+          const: 100
+        scoreBands:
+          type: object
+          required: [approved, review, rejected]
+          properties:
+            approved:
+              $ref: "#/components/schemas/ScoreBand"
+            review:
+              $ref: "#/components/schemas/ScoreBand"
+            rejected:
+              $ref: "#/components/schemas/ScoreBand"
+        rules:
+          type: array
+          minItems: 5
+          maxItems: 5
+          items:
+            type: object
+            required: [rule, weight, parameters]
+            properties:
+              rule:
+                type: string
+              weight:
+                type: integer
+              parameters:
+                type: object
+                additionalProperties: true
+    ScoreBand:
+      type: object
+      additionalProperties: false
+      required: [min, max]
+      properties:
+        min:
+          type: integer
+        max:
+          type: integer
+    Readiness:
+      type: object
+      additionalProperties: false
+      required: [status, mode, dependencies]
+      properties:
+        status:
+          type: string
+          const: ready
+        mode:
+          type: string
+          enum: [normal, degraded]
+        dependencies:
+          type: object
+          additionalProperties: false
+          required: [redis]
+          properties:
+            redis:
+              type: string
+              enum: [unknown, available, unavailable]
+    Error:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: string
+        message:
+          type: string
+        details:
+          type: array
+          items:
+            type: object
+            required: [path, message]
+            properties:
+              path:
+                type: string
+              message:
+                type: string

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,73 @@
+# Architecture générale
+
+## Objectif
+
+Transaction Risk Gate reçoit une transaction synthétique, applique des règles heuristiques
+expliquées et retourne `APPROVED`, `REVIEW` ou `REJECTED`. Le projet démontre surtout la
+construction d’un petit service exploitable : sécurité, cohérence multi-replica, tests,
+observabilité et livraison.
+
+## Vue des conteneurs
+
+```mermaid
+flowchart LR
+    User[Utilisateur] -->|HTTPS| Web[Web public\nHTML CSS JavaScript + Nginx]
+    Web -->|API privée + secret interservice| Api[API Fastify\nplusieurs replicas]
+    Api -->|état HMAC + TCP interne authentifié| Redis[(Redis privé)]
+    Api -->|logs et métriques| Monitor[Azure Monitor\nLog Analytics]
+    GitHub[GitHub Actions] -->|OIDC| Azure[Azure Container Apps]
+    GitHub -->|images par SHA et digest| Registry[Azure Container Registry]
+    Registry --> Azure
+    Azure --> Web
+    Azure --> Api
+```
+
+Le navigateur ne reçoit jamais le secret interservice. Nginx sert l’interface et relaie `/api/*`
+vers l’API privée en injectant ce secret côté serveur.
+
+## Responsabilités
+
+| Élément | Responsabilité                                       | Exposition        |
+| ------- | ---------------------------------------------------- | ----------------- |
+| Web     | formulaire, scénarios, restitution explicable        | publique en HTTPS |
+| API     | validation, règles, sécurité, idempotence, métriques | privée            |
+| Redis   | vélocité et idempotence partagées avec TTL           | privée            |
+| ACR     | images immuables identifiées par digest              | authentifiée      |
+| Monitor | logs structurés, métriques et alertes                | opérateurs        |
+
+## Flux d’une décision
+
+```mermaid
+sequenceDiagram
+    participant U as Utilisateur
+    participant W as Web
+    participant A as API
+    participant R as Redis
+
+    U->>W: Soumettre une transaction synthétique
+    W->>A: POST /api/decisions + Idempotency-Key
+    A->>R: Réserver la clé d'idempotence
+    R-->>A: Réponse existante ou verrou acquis
+    A->>R: Incrémenter atomiquement la vélocité
+    R-->>A: Compteur partagé
+    A->>A: Valider et calculer le score
+    A->>R: Mémoriser la réponse et libérer le verrou
+    A-->>W: Décision, score et raisons
+    W-->>U: Résultat expliqué
+```
+
+Si Redis est indisponible, l’API ne peut pas prouver la vélocité globale. Elle reste disponible mais
+force `REVIEW` avec `degraded=true`; elle ne produit jamais `APPROVED` dans cet état.
+
+## État d’implémentation
+
+TRG-2 sépare le moteur métier pur du cas d’usage qui obtient la vélocité. TRG-3 remplace l'état
+local par Redis pour la vélocité et l'idempotence, ajoute un circuit breaker et formalise le mode
+dégradé. TRG-4 durcit les frontières HTTP, partage le rate limiting, structure les logs et métriques
+et teste la redaction. TRG-5 livre le simulateur web sans exposer de secret ni de flux global des
+décisions. TRG-6 impose couverture, SonarCloud, Snyk, Gitleaks et Trivy. TRG-7 rend les images
+non-root, décrit les trois environnements logiques et fournit l'IaC Azure idempotente. Le workflow
+TRG-8 publie les images déjà scannées, promeut les mêmes digests et restaure les révisions
+précédentes lorsqu'un smoke test échoue. TRG-9 fournit OpenAPI, Postman, les profils k6 et les
+runbooks de panne. La performance ne devient une preuve qu'après un run réel ; un déploiement cloud
+n'est déclaré réussi qu'avec son exécution GitHub verte.

--- a/docs/decisions/ADR-001-typescript-fastify.md
+++ b/docs/decisions/ADR-001-typescript-fastify.md
@@ -1,0 +1,53 @@
+# ADR-001 — TypeScript strict et Fastify
+
+## Statut
+
+Acceptée. Mise en œuvre progressive à partir de `TRG-2`.
+
+## Contexte
+
+Le projet doit démontrer une petite application cloud compréhensible, testable et observable. La
+candidature n’impose aucune stack. Le portefeuille contient déjà une référence Java/Spring plus
+lourde ; ce projet doit montrer que les pratiques d’architecture et de livraison sont indépendantes
+du langage.
+
+## Décision
+
+L’API utilise Node.js, TypeScript en mode strict et Fastify. Le web reste léger en HTML, CSS et
+JavaScript, servi par Nginx.
+
+Fastify est retenu pour sa faible surcharge, ses performances, son cycle de vie explicite, sa
+journalisation structurée et son intégration naturelle avec une validation de schéma. TypeScript
+strict réduit les états implicites et rend les contrats du domaine visibles sans introduire un
+framework applicatif massif.
+
+Le domaine de risque reste indépendant des routes et de Redis afin d’être testé sans serveur ni
+réseau.
+
+## Conséquences
+
+Positives :
+
+- démarrage et image rapides ;
+- tests unitaires simples avec le runner Node ;
+- validation et sérialisation proches du contrat ;
+- code adapté à une démonstration cloud multi-replica.
+
+Contraintes :
+
+- la discipline d’architecture doit être imposée par la structure et les tests ;
+- les versions Node, npm et dépendances doivent être épinglées ;
+- les erreurs asynchrones et l’arrêt du serveur nécessitent des tests dédiés.
+
+## Alternatives écartées
+
+| Option           | Motif                                                                                    |
+| ---------------- | ---------------------------------------------------------------------------------------- |
+| Java/Spring Boot | excellente option, mais déjà démontrée dans un autre projet et plus lourde ici           |
+| Express          | écosystème large, mais davantage de composition manuelle pour validation et cycle de vie |
+| NestJS           | structure complète mais disproportionnée pour ce périmètre                               |
+
+## Vérification attendue
+
+Compilation TypeScript stricte, tests du domaine sans Fastify, tests d’injection HTTP, couverture
+bloquante et image exécutée sans privilège.

--- a/docs/decisions/ADR-002-coherence-redis.md
+++ b/docs/decisions/ADR-002-coherence-redis.md
@@ -1,0 +1,67 @@
+# ADR-002 — Cohérence distribuée avec Redis
+
+## Statut
+
+Acceptée et implémentée dans `TRG-3`.
+
+## Contexte
+
+Plusieurs replicas API ne partagent pas leur mémoire. Sans état externe, trois transactions de la
+même carte peuvent atteindre trois instances différentes et chaque instance peut croire qu’elle ne
+voit qu’une transaction. L’idempotence souffre du même problème lors de requêtes concurrentes.
+
+## Décision
+
+Redis porte uniquement l’état temporaire partagé :
+
+- compteur de vélocité atomique, TTL 60 secondes ;
+- réservation et réponse d’idempotence, TTL 24 heures ;
+- détection d’une même clé associée à un payload différent ;
+- coordination d’une seule évaluation pour les requêtes concurrentes.
+
+L’identifiant de carte est transformé par HMAC avant de devenir une clé. Redis n’est ni une base
+métier permanente, ni un stockage de logs ou d’audit.
+
+Timeout initial : 250 ms. Après trois erreurs, le circuit s’ouvre pendant 10 secondes puis autorise
+une requête de test. Ces valeurs restent configurables et seront ajustées après mesure.
+
+## Mode dégradé
+
+Si Redis est indisponible, l’API ne peut pas prouver la vélocité globale. Elle force donc :
+
+```json
+{
+  "decision": "REVIEW",
+  "degraded": true,
+  "reasons": [
+    {
+      "rule": "RISK_CONTEXT_UNAVAILABLE"
+    }
+  ]
+}
+```
+
+Le score devient au minimum le seuil `REVIEW`. Une panne ne peut jamais réduire le risque ni
+produire `APPROVED`. L’événement est journalisé sans donnée sensible et alimente des métriques de
+panne, décision dégradée et rétablissement.
+
+## Conséquences
+
+Positives : cohérence entre replicas, opérations atomiques et réponse sûre à une panne. Coûts :
+dépendance réseau supplémentaire, configuration de secrets et tests d’intégration réels.
+
+## Alternatives écartées
+
+| Option                   | Motif                                                            |
+| ------------------------ | ---------------------------------------------------------------- |
+| mémoire locale           | incohérente avec plusieurs replicas                              |
+| continuer sans vélocité  | peut approuver une transaction risquée                           |
+| retourner uniquement 503 | disponibilité plus faible alors qu’une revue sûre reste possible |
+| base relationnelle       | durable et plus lourde que cet état court et atomique            |
+
+## Vérification attendue
+
+Les tests unitaires couvrent TTL, replay, conflit `409`, concurrence, timeout, ouverture et
+rétablissement du circuit. Les tests d'intégration exécutés avec un vrai Redis vérifient le partage
+multi-replica, les opérations atomiques, l'expiration et l'absence des identifiants bruts dans les
+clés. La CI fournit le service Redis nécessaire ; ces scénarios ne sont pas simulés par un mock.

--- a/docs/decisions/ADR-003-hebergement-azure.md
+++ b/docs/decisions/ADR-003-hebergement-azure.md
@@ -1,0 +1,66 @@
+# ADR-003 — Hébergement sur Azure Container Apps
+
+## Statut
+
+Acceptée. Infrastructure implémentée dans `TRG-7`; livraison immuable et rollback automatisés dans
+`TRG-8`.
+
+## Contexte
+
+Le cahier des charges demande conteneurisation, CI/CD, déploiement cloud et comportement sous
+charge. La solution doit pouvoir augmenter le nombre de replicas sans gérer directement un cluster
+Kubernetes.
+
+## Décision
+
+Azure Container Apps héberge le web et l’API. Azure Container Registry conserve les images. GitHub
+Actions s’authentifie par OIDC, construit une seule fois puis déploie des digests immuables.
+
+Topologie visée :
+
+```text
+Internet -> web public -> API privée -> Redis privé
+```
+
+Les branches utilisent trois environnements logiques :
+
+| Branche            | Environnement |
+| ------------------ | ------------- |
+| `develop`          | intégration   |
+| `release/*`        | préproduction |
+| `main` ou tag `v*` | production    |
+
+Les environnements partagent ACR, Log Analytics et l'environnement Container Apps, mais possèdent
+des apps Redis/API/web, des secrets et un état distincts. Cette mutualisation réduit le coût de cet
+exercice ; une séparation physique reste une évolution de production.
+
+## Sécurité et exploitation
+
+- HTTPS uniquement sur l’entrée publique ;
+- API et Redis sans exposition Internet directe ;
+- secrets injectés au runtime ;
+- identité OIDC sans secret Azure permanent dans GitHub ;
+- images identifiées par SHA et digest, jamais déployées depuis `latest` ;
+- health, readiness, métriques, logs structurés et arrêt gracieux ;
+- révision précédente conservée pour rollback.
+
+## Conséquences
+
+Container Apps simplifie l’autoscaling et les révisions, mais lie le premier déploiement à Azure.
+L’architecture applicative et les conteneurs restent portables ; les scripts d’exploitation Azure ne
+le sont pas. Le Redis conteneurisé privé réduit le coût mais n'offre ni SLA managé, ni TLS
+applicatif, ni persistance ; Azure Managed Redis est l'évolution de production.
+
+## Alternatives écartées
+
+| Option               | Motif                                                                |
+| -------------------- | -------------------------------------------------------------------- |
+| machine virtuelle    | trop d’exploitation système pour cet exercice                        |
+| AKS                  | contrôle puissant mais disproportionné en coût et complexité         |
+| fonctions serverless | cycle de vie et connexion Redis moins lisibles pour la démonstration |
+
+## Vérification attendue
+
+Déploiement OIDC, ingress privé, plusieurs `X-Instance-Id`, smoke tests, montée en charge, panne
+Redis et rollback vers une révision antérieure. TRG-8 automatise ces opérations ; une exécution
+cloud verte et ses artefacts restent la preuve attendue, pas la seule présence du YAML.

--- a/docs/exploitation.md
+++ b/docs/exploitation.md
@@ -1,0 +1,100 @@
+# Exploitation et observabilité
+
+## Signaux de service
+
+| Endpoint   | Signification                                       | Authentification             |
+| ---------- | --------------------------------------------------- | ---------------------------- |
+| `/health`  | le processus répond                                 | aucune                       |
+| `/ready`   | l'instance accepte du trafic ; expose le mode Redis | aucune                       |
+| `/metrics` | métriques Prometheus                                | aucune, API sur réseau privé |
+
+Une panne Redis conserve `/ready` à `200` avec `mode: degraded` car l'API produit encore une
+décision sûre `REVIEW`. Un arrêt gracieux bascule immédiatement `/ready` à `503`, attend le retrait
+du load balancer, draine les connexions puis ferme Redis. Le conteneur dispose de 30 secondes,
+supérieures au délai et au timeout configurés.
+
+## Logs structurés
+
+Chaque ligne Pino contient `timestamp`, `level`, `service`, `environment`, `version`, `instanceId`,
+`event` et, pour une requête, `requestId`.
+
+| Famille      | Événements principaux                                                           |
+| ------------ | ------------------------------------------------------------------------------- |
+| HTTP         | `http_request_completed`, `http_request_aborted`, `http_request_timeout`        |
+| métier/audit | décision créée ou rejouée, score et règles sans valeurs reçues                  |
+| sécurité     | `authentication_denied`, `rate_limit_exceeded`, `request_rejected`              |
+| Redis        | `redis_unavailable`, `redis_recovered`, `redis_circuit_transition`              |
+| cycle de vie | `server_listening`, `shutdown_started`, `shutdown_completed`, `shutdown_failed` |
+
+Les routes, statuts et durées sont journalisés, jamais l'URL brute avec sa query, le corps ou les
+headers. La redaction Pino couvre aussi tout objet nommé `payload`, `body`, `transaction`, `cardId`,
+`apiKey` ou `loadTestToken`.
+
+## Métriques
+
+- `http_request_duration_seconds{method,route,status_code}` : latence par frontière stable ;
+- `http_requests_in_flight` : drainage et saturation ;
+- `http_requests_aborted_total{reason}` : abandons et timeouts ;
+- `decisions_total{decision,degraded}` et `degraded_decisions_total` ;
+- `authentication_failures_total` et `rate_limit_exceeded_total{profile}` ;
+- `rate_limit_fallback_total` : protection locale utilisée faute de Redis ;
+- `shared_state_errors_total` et `redis_circuit_transitions_total{from,to}` ;
+- `request_failures_total{code}` : frontières rejetées par raison stable ;
+- métriques Node : mémoire, garbage collector et event loop.
+
+Les labels sont bornés par le code. Aucun identifiant de carte, de transaction, d'instance ou de
+requête ne devient un label Prometheus, afin d'éviter une cardinalité incontrôlée.
+
+## Alertes initiales
+
+| Alerte               | Condition de départ                               |
+| -------------------- | ------------------------------------------------- |
+| erreurs HTTP         | taux `5xx` supérieur à 1 % pendant 5 minutes      |
+| latence              | p95 supérieur à l'objectif après benchmark        |
+| état partagé         | décision dégradée ou circuit Redis ouvert         |
+| rate limiting réduit | augmentation de `rate_limit_fallback_total`       |
+| disponibilité        | aucun replica prêt ou smoke test en échec         |
+| déploiement          | nouvelle révision non prête dans le délai attendu |
+
+Les budgets mesurés et désormais appliqués sont `250/500 ms` pour `baseline`, `750/1000 ms` pour
+`scale` et `1250/1750 ms` pour `stress` (p95/p99). Ils distinguent l'objectif interactif de la
+caractérisation sous saturation et restent justifiés par les preuves TRG-9/TRG-16. La rétention
+cible est 30 jours hors production et 90 jours en production.
+
+## Diagnostic Azure Log Analytics
+
+Exemples à adapter au nom de la table Container Apps :
+
+```kusto
+ContainerAppConsoleLogs_CL
+| where Log_s has '"event":"redis_unavailable"'
+| project TimeGenerated, Log_s
+| order by TimeGenerated desc
+```
+
+```kusto
+ContainerAppConsoleLogs_CL
+| where Log_s has '"event":"http_request_completed"'
+| summarize count() by bin(TimeGenerated, 5m)
+```
+
+Le diagnostic suit `requestId` pour une requête et `decisionId` pour la preuve métier. Les données
+sensibles ne doivent jamais être nécessaires à une recherche opérationnelle.
+
+## Déploiement et récupération
+
+Le workflow capture les révisions actives avant tout changement, déploie uniquement des références
+ACR par digest puis exécute santé, readiness, règles et décision idempotente à travers le web
+public. Si le smoke test échoue, `infra/rollback.sh` remet 100 % du trafic sur les deux révisions
+précédentes et le test est rejoué. Le candidat demeure refusé même si le service restauré est sain.
+
+Un rollback manuel utilise le même runbook depuis l'action `Déploiement`. L'opérateur sélectionne
+`integration`, `preproduction` ou `production` et peut fournir des révisions précises. En l'absence
+de valeurs, le script choisit la révision immédiatement antérieure. Le détail de la chaîne et des
+preuves figure dans [Livraison, promotion et rollback](livraison.md).
+
+## Vérifications
+
+Les tests couvrent corrélation, headers de sécurité, limite de payload, profils de charge, redaction
+réelle, métriques, mode dégradé, circuit Redis et drainage. Le test SIGTERM s'exécute dans la CI
+Linux, car Windows ne reproduit pas ce signal fidèlement.

--- a/docs/governance/definition-of-done.md
+++ b/docs/governance/definition-of-done.md
@@ -1,0 +1,81 @@
+# Definition of Done
+
+Un élément est terminé seulement si toutes les exigences applicables possèdent une preuve.
+`Non applicable` nécessite une justification dans la PR.
+
+## Prêt à développer
+
+- [ ] L’issue `TRG-N`, le périmètre, le risque et la release sont identifiés.
+- [ ] La branche et les chemins concernés sont connus.
+- [ ] Les critères couvrent réussite, rejet et panne applicables.
+- [ ] Les décisions d’architecture bloquantes sont fermées ou documentées.
+- [ ] Les impacts sécurité, données et exploitation sont classifiés.
+- [ ] Le changement est assez petit pour être relu, testé et récupéré seul.
+
+## Toute pull request
+
+- [ ] Issue, branche, commits et titre utilisent le même `TRG-N`.
+- [ ] La branche suit la politique et possède un upstream de même nom.
+- [ ] Les labels `type`, `risk`, `area` et `release` sont complets.
+- [ ] Le diff est cohérent et ne contient aucun fichier local ou généré.
+- [ ] Les hooks locaux et les contrôles ciblés ont réussi.
+- [ ] La CI obligatoire a réussi sans skip caché ni tolérance d’échec.
+- [ ] Une review facultative demandée pour un changement sensible est terminée.
+- [ ] Toutes les discussions ouvertes sont résolues.
+- [ ] Documentation et stratégie de récupération sont à jour.
+
+## Code et architecture
+
+- [ ] Les limites domaine, application et infrastructure restent explicites.
+- [ ] Les tests prouvent les règles et les cas limites, pas seulement des lignes.
+- [ ] Les chemins négatifs de sécurité sont testés.
+- [ ] Concurrence, idempotence, panne et redémarrage sont testés si concernés.
+- [ ] La couverture globale reste au moins à 80 %.
+- [ ] Le domaine métier vise une couverture supérieure à 90 %.
+- [ ] Sonar, Snyk, Gitleaks et Trivy respectent leurs seuils applicables.
+- [ ] Le comportement public est documenté tel qu’implémenté.
+
+## API ou contrat
+
+- [ ] OpenAPI est modifié avec le comportement.
+- [ ] Headers, erreurs, idempotence et exemples synthétiques sont représentés.
+- [ ] Validation et compatibilité du contrat réussissent.
+- [ ] Une rupture possède une version et une stratégie de migration explicites.
+
+## Sécurité
+
+- [ ] Les frontières de confiance et scénarios d’abus sont à jour.
+- [ ] Authentification incorrecte, replay et élévation de privilèges sont évalués.
+- [ ] Les secrets et identifiants sont expurgés des réponses et de la télémétrie.
+- [ ] Une dépendance indisponible échoue de façon sûre.
+- [ ] Aucune vulnérabilité Critical ou High exploitable ne reste ouverte.
+
+## Documentation
+
+- [ ] Le document canonique est modifié sans créer une source concurrente.
+- [ ] Les diagrammes Mermaid correspondent aux frontières réelles.
+- [ ] Les liens et blocs de code sont valides.
+- [ ] Aucun chemin de poste, token, URL privée ou donnée réelle n’est présent.
+
+## CI, conteneur ou livraison
+
+- [ ] Les permissions suivent le moindre privilège.
+- [ ] Les Actions, outils et images sont épinglés.
+- [ ] Aucun contrôle obligatoire n’est devenu optionnel.
+- [ ] Les images s’exécutent sans privilège et ne sont pas promues par `latest`.
+- [ ] Commit, image, digest et environnement restent traçables.
+- [ ] Le déploiement échoué laisse la version précédente récupérable.
+
+## Release
+
+- [ ] Un même digest traverse validation et production sans reconstruction.
+- [ ] Régression, sécurité, smoke, charge et panne applicables sont validés.
+- [ ] Documentation, limites et runbooks sont à jour.
+- [ ] Le tag SemVer pointe vers le commit accepté et reste immuable.
+- [ ] Les preuves identifient commit, digests, environnement et date.
+
+## Conditions « non terminé »
+
+Le travail n’est pas terminé si un test ne passe qu’après un retry inexpliqué, si un scanner
+obligatoire est absent, si la couverture est contournée, si un comportement n’est pas documenté, si
+une vulnérabilité bloquante reste ouverte ou si un artefact différent de celui testé est promu.

--- a/docs/governance/git-policy.md
+++ b/docs/governance/git-policy.md
@@ -1,0 +1,129 @@
+# Politique Git
+
+## But
+
+Cette politique relie une issue, une branche, ses commits et sa pull request. Les hooks donnent un
+retour rapide ; GitHub Actions et les rulesets restent l’autorité.
+
+## Branches
+
+Les branches de travail utilisent :
+
+```text
+<classe>/TRG-<numéro>-<description-kebab-case>
+```
+
+Classes autorisées :
+
+- `feat` : fonctionnalité ;
+- `fix` : correction ;
+- `security` : durcissement ou vulnérabilité ;
+- `test` : tests sans changement métier principal ;
+- `docs` : documentation ;
+- `refactor` : restructuration sans changement fonctionnel voulu ;
+- `ci` : build, livraison ou infrastructure ;
+- `chore` : maintenance ;
+- `hotfix` : correctif urgent créé depuis `main`.
+
+Exemples valides :
+
+```text
+feat/TRG-2-risk-engine
+security/TRG-4-api-observability
+ci/TRG-8-cicd-release-automation
+hotfix/TRG-10-redis-timeout
+```
+
+Les branches `feat`, `fix`, `security`, `test`, `docs`, `refactor`, `ci` et `chore` ciblent
+`develop`. Une `hotfix` cible `main` puis son changement est réintégré dans `develop`. Une release
+utilise `release/v<major>.<minor>.<patch>` et cible `main`.
+
+`main`, `develop` et `release/*` sont protégées : aucun push direct, suppression ou force-push
+normal. Les branches sources sont volontairement conservées après fusion pour démontrer le cycle de
+livraison.
+
+Dependabot constitue la seule exception de nommage automatisée. Ses PR ciblent `develop`, utilisent
+le work item `TRG-6` configuré et restent soumises aux labels et checks. GitHub ajoute
+automatiquement un deux-points au préfixe des commits (`[TRG-6]: ...`) : cette variante est acceptée
+uniquement sur les branches `dependabot/*`. Les branches humaines conservent strictement le format
+`[TRG-N] ...` sans deux-points.
+
+## Commits
+
+Format court :
+
+```text
+[TRG-2] implementer le moteur de risque
+```
+
+Format long :
+
+```text
+[TRG-3] garantir l idempotence distribuee
+
+- reserver atomiquement la cle Redis
+- rejouer une reponse pour un payload identique
+```
+
+Règles :
+
+- même numéro que la branche ;
+- sujet de 72 caractères maximum ;
+- verbe à l’infinitif commençant en minuscule ;
+- aucun point final ;
+- une intention logique par commit ;
+- corps optionnel séparé par une ligne vide ;
+- chaque ligne non vide du corps commence par `-` suivi d’une espace ;
+- aucun secret, rapport généré ou donnée réelle.
+
+Les commits `Merge` et `Revert` générés par Git sont acceptés. Les commits directs sur une branche
+protégée sont rejetés.
+
+Les mises à jour Dependabot restent relues avant fusion. Un titre généré trop long est raccourci,
+les montées de version majeure sont traitées dans une issue dédiée et les mêmes quality gates que
+pour une contribution humaine restent obligatoires.
+
+## Pull requests
+
+Le titre reprend l’identité :
+
+```text
+[TRG-2] implementer le moteur de risque explicable
+```
+
+Chaque PR :
+
+- cible la branche prévue par sa classe ;
+- référence l’issue et décrit inclusions et exclusions ;
+- possède exactement un label `type:*`, `risk:*` et `release:*` ;
+- possède au moins un label `area:*` ;
+- peut demander une review humaine pour un changement sensible ;
+- décrit tests, sécurité, documentation et récupération ;
+- attend les checks obligatoires et la résolution des discussions.
+
+Le job `Gouvernance` ajoute automatiquement les labels de zone selon les chemins avant de les
+contrôler. Le type, le risque et l’impact release restent des décisions explicites de l’auteur.
+
+## Fusions
+
+- travail vers `develop` : merge commit privilégié pour conserver l’histoire ;
+- `release/*` vers `main` : merge commit obligatoire ;
+- approbation humaine facultative sur ce projet individuel ;
+- nouvelle validation des checks après chaque changement de la tête de PR ;
+- aucune fusion avec discussion ouverte ou contrôle obligatoire rouge.
+
+La CI réussie doit correspondre au SHA courant de la PR. Une réussite ancienne ne couvre pas un
+nouveau push.
+
+## Contrôles exécutables
+
+| Moment     | Contrôles                                                    |
+| ---------- | ------------------------------------------------------------ |
+| pre-commit | fichiers, secrets, Markdown, politique du dépôt              |
+| commit-msg | identité branche/commit et forme du message                  |
+| pre-push   | branche, upstream, diff, gouvernance, build et tests rapides |
+| PR         | titre, cible, labels, discussions et CI complète applicable  |
+| release    | régression, sécurité, charge, smoke et artefact immuable     |
+
+Un contournement local n’affaiblit jamais la CI. Il sert uniquement au diagnostic et doit être
+expliqué dans la PR.

--- a/docs/governance/quality-security-gates.md
+++ b/docs/governance/quality-security-gates.md
@@ -1,0 +1,150 @@
+# Quality, Security and Test Gates
+
+## Principes
+
+1. Les tests prouvent le comportement ; la couverture révèle les zones non testées mais ne remplace
+   pas les assertions utiles.
+2. Les frontières sensibles exigent des tests positifs, négatifs, de concurrence et de panne.
+3. Les contrôles obligatoires échouent si l’outil ou sa configuration manque.
+4. Les hooks accélèrent le retour local ; la CI reste l’autorité.
+5. Les rapports ne contiennent ni secret ni donnée bancaire.
+6. Un test instable est un défaut, pas une raison d’ajouter un retry caché.
+
+## Typologie des tests
+
+| Suite             | But                                     | Exécution minimale               |
+| ----------------- | --------------------------------------- | -------------------------------- |
+| unitaire          | règles et politiques pures              | pre-push, PR, branches protégées |
+| API               | validation, auth, erreurs et headers    | PR, branches protégées           |
+| intégration Redis | atomicité, TTL, concurrence, panne      | PR concernée, release            |
+| web               | formulaire, scénarios et restitution    | PR, branches protégées           |
+| contrat           | conformité OpenAPI                      | PR concernée, branches protégées |
+| résilience        | timeout, circuit breaker, shutdown      | PR concernée, release            |
+| smoke             | application réellement déployée         | après déploiement                |
+| charge            | latence, erreurs, replicas et cohérence | manuel, préproduction, release   |
+
+Les tests utilisent horloges, identifiants et données synthétiques déterministes. Aucun test rapide
+ne dépend d’Internet ou d’un environnement partagé.
+
+## Couverture
+
+| Portée                    |           Lignes |         Branches |
+| ------------------------- | ---------------: | ---------------: |
+| code de production global |          >= 80 % |          >= 80 % |
+| code nouveau ou modifié   |          >= 80 % |          >= 80 % |
+| domaine de décision       | objectif >= 90 % | objectif >= 90 % |
+
+Seuls les fichiers générés vérifiés et un bootstrap trivial peuvent être exclus. Une exclusion
+nécessite une justification et une review. Un test créé uniquement pour exécuter une ligne sans
+vérifier son résultat est refusé.
+
+Les commandes bloquantes sont `npm run test:coverage --prefix api` et
+`npm run test:coverage --prefix web`. Le domaine possède en plus une porte renforcée à 90 % via
+`npm run test:coverage:domain --prefix api`. Les exclusions versionnées sont limitées à :
+
+- `api/src/decision.ts`, contrat TypeScript sans code exécutable ;
+- `api/src/server.ts`, composition root vérifiée par build, smoke tests et test SIGTERM ;
+- `web/dev-server.mjs`, outil local absent de l’image de production.
+
+## SonarCloud
+
+L’analyse est obligatoire sur toutes les PR vers `develop`, `release/*` et `main`. Une analyse de la
+branche principale Sonar est aussi exécutée après chaque merge dans `main`.
+
+| Mesure du nouveau code | Seuil   |
+| ---------------------- | ------- |
+| bugs                   | 0       |
+| vulnérabilités         | 0       |
+| reliability rating     | A       |
+| security rating        | A       |
+| maintainability rating | A       |
+| hotspots revus         | 100 %   |
+| couverture             | >= 80 % |
+| lignes dupliquées      | < 3 %   |
+
+La CI génère LCOV avant l’analyse et attend explicitement le Quality Gate. Un token, une
+organisation ou un projet absent fait échouer le job obligatoire. SonarQube for IDE utilise le
+connected mode sans token versionné.
+
+Le projet utilise l'offre gratuite SonarQube Cloud : elle permet l'analyse de la branche principale
+et des PR, mais pas l'analyse directe de plusieurs branches. `main` reste donc la branche principale
+du projet Sonar, comme sur GitHub. Les branches durables n'introduisent aucun code directement :
+leur PR est analysée et bloquée, puis elles promeuvent le même candidat immuable déjà validé. Le job
+`SonarCloud` reste obligatoire sur les pushes `develop` et `release/*` et confirme explicitement
+cette provenance, sans lancer une fausse analyse de branche non prise en charge par l'abonnement.
+
+Le dépôt partage l’identité publique du projet dans `.sonarlint/connectedMode.json` et recommande
+l’extension dans `.vscode/extensions.json`. Chaque développeur conserve son propre jeton dans son
+éditeur ; le fichier partagé ne contient aucune authentification.
+
+## Sécurité
+
+| Surface            | Outil                       | Règle bloquante                       |
+| ------------------ | --------------------------- | ------------------------------------- |
+| secrets source     | Gitleaks et Push Protection | tout secret vérifié                   |
+| dépendances        | Snyk Open Source            | Critical ou High exploitable          |
+| code               | Snyk Code et Sonar          | Critical ou High exploitable          |
+| images             | Trivy                       | Critical ou High exploitable          |
+| IaC et topologie   | Bicep et Docker Compose     | compilation ou configuration invalide |
+| dépendances GitHub | Dependabot                  | alerte triée et corrigée selon risque |
+| provenance         | SHA, digest et métadonnées  | mapping absent ou mutable             |
+
+Les constats Medium reçoivent une analyse, un propriétaire et une échéance. Une exception précise
+justification, portée, compensation, approbateur et expiration ; elle ne peut jamais couvrir une
+fuite de secret ou un fail-open.
+
+Snyk utilise `SNYK_ORG` pour attribuer explicitement les tests à l’organisation préparée. Le CLI
+exécute `test --all-projects` et `code test` sur chaque PR, puis `monitor` uniquement après un push
+sur une branche durable. Trivy couvre les deux images et bloque les vulnérabilités HIGH ou CRITICAL
+pour lesquelles un correctif existe ; les constats amont non corrigibles restent visibles et sont
+réévalués par Dependabot.
+
+## Étages des contrôles
+
+### Pre-commit
+
+- fin de fichier, espaces, LF et conflits ;
+- validité JSON/YAML et conflits de casse ;
+- fichiers volumineux et clés privées ;
+- Gitleaks sur les changements indexés ;
+- Markdown et liens documentaires ;
+- politique de structure du dépôt.
+
+### Pre-push
+
+- nom et upstream de branche ;
+- interdiction des références protégées ;
+- diff sans erreur d’espace ;
+- tests des règles de gouvernance ;
+- build API et tests API/web rapides.
+
+### CI de PR
+
+Le flux cible est :
+
+```mermaid
+flowchart LR
+    Governance[Gouvernance et secrets] --> Static[Format lint types]
+    Governance --> IaC[Bicep et Compose]
+    Static --> Tests[Tests et couverture]
+    Tests --> Sonar[Sonar Quality Gate]
+    Tests --> Snyk[Snyk Open Source et Code]
+    Sonar --> Images[Images Docker non-root]
+    Snyk --> Images
+    IaC --> Images
+    Images --> Trivy[Scan Trivy]
+    Trivy --> Admission[Merge autorisé]
+    Admission --> Publish[Publication du candidat par digest]
+    Publish --> Smoke[Déploiement et smoke test]
+```
+
+Les jobs indépendants peuvent fonctionner en parallèle, mais aucune image ou release n’est acceptée
+sans toutes les preuves applicables. La publication recharge exactement l'artefact Docker scanné ;
+elle ne reconstruit pas les images après Trivy. Un smoke test rouge déclenche le rollback et laisse
+le workflow rouge.
+
+## Rapports
+
+Les détails vivent dans GitHub Actions, SonarCloud et Snyk. Git conserve les politiques, décisions
+et résumés de release, pas un export daté après chaque commit. Les artefacts CI sont expurgés et
+possèdent une rétention limitée.

--- a/docs/governance/release-policy.md
+++ b/docs/governance/release-policy.md
@@ -1,0 +1,99 @@
+# Politique de release
+
+## Versionnement
+
+Le projet suit Semantic Versioning :
+
+- `MAJOR` pour une rupture de contrat ;
+- `MINOR` pour une fonctionnalité compatible ;
+- `PATCH` pour une correction compatible.
+
+La première version visée est `v1.0.0`. Un tag publié n’est jamais déplacé ou réutilisé ; une
+correction produit une nouvelle version.
+
+## Flux des branches
+
+```mermaid
+flowchart LR
+    Work[feat fix security ci docs] --> Develop[develop]
+    Develop --> Release[release/v1.0.0]
+    Release --> Main[main]
+    Main --> Tag[tag v1.0.0]
+    Hotfix[hotfix/TRG-N-topic] --> Main
+    Hotfix --> Develop
+```
+
+| Branche     | Rôle                                 | Déploiement          |
+| ----------- | ------------------------------------ | -------------------- |
+| travail     | changement isolé en PR               | aucun                |
+| `develop`   | intégration continue                 | intégration          |
+| `release/*` | stabilisation sans nouvelle fonction | préproduction        |
+| `main`      | état publiable                       | production contrôlée |
+| `hotfix/*`  | correction urgente depuis `main`     | après validation     |
+
+## Construction et promotion
+
+```text
+commit accepté
+-> images api/web taguées par SHA
+-> scans et smoke tests
+-> résolution des digests immuables
+-> promotion des mêmes digests
+-> tag SemVer et GitHub Release
+```
+
+Une release ne reconstruit jamais un artefact différent après validation. Le tag `latest` peut
+exister comme alias humain hors promotion, mais ne constitue jamais une entrée de déploiement ou de
+rollback.
+
+Le candidat publié depuis `develop` est décrit dans `.release/manifest.json` lors de la création de
+`release/vX.Y.Z`. Ce manifeste versionné associe la version SemVer, le SHA source et les deux
+digests ACR. La CI refuse les champs supplémentaires, les références mutables, un registre inattendu
+ou toute modification postérieure dans les contextes de construction `api/` et `web/`. Les fichiers
+de procédure, d'infrastructure et de documentation peuvent être corrigés sans reconstruire les
+images, mais restent soumis à l'ensemble des Quality Gates. La préproduction et la production
+consomment ensuite le même manifeste.
+
+## Critères d’admission
+
+Avant la PR `release/* -> main` :
+
+- CI, couverture, Sonar, Snyk, Gitleaks et Trivy verts ;
+- régression complète ;
+- smoke tests sur santé, readiness et décision métier ;
+- scénarios de charge et de panne applicables ;
+- digests, commit et environnement enregistrés ;
+- limites, rollback et notes de release à jour ;
+- discussions ouvertes résolues et checks obligatoires verts.
+
+La création d’un tag final suit l’acceptation de la PR et pointe vers le commit fusionné. GitHub
+Release contient le résumé, les limites et les digests promus.
+
+Le runbook détaillé, les responsabilités des workflows et le contenu du smoke test sont décrits dans
+[Livraison, promotion et rollback](../livraison.md).
+
+## Rollback
+
+Le rollback sélectionne la révision Azure précédente associée à un digest déjà accepté. Il ne
+reconstruit pas le code. Après rollback :
+
+1. vérifier `/health` et `/ready` ;
+2. exécuter une décision synthétique ;
+3. confirmer erreurs, latence et état Redis ;
+4. documenter l’incident et ouvrir un correctif `TRG-N` ;
+5. réintégrer tout hotfix dans `develop`.
+
+## Échec d’une release
+
+Un test, scanner, déploiement ou smoke test rouge rejette le candidat. La révision de production
+précédente reste active. Une panne d’outil obligatoire n’est pas transformée en succès et aucune
+exception silencieuse n’est permise.
+
+## Preuves conservées
+
+- SHA source et tag ;
+- digests API et web ;
+- résultats synthétiques de tests et couverture ;
+- état des quality/security gates ;
+- environnement, date et approbateur ;
+- résultat des smoke tests et procédure de récupération.

--- a/docs/interface-web.md
+++ b/docs/interface-web.md
@@ -1,0 +1,71 @@
+# Interface web de démonstration
+
+## Objectif
+
+Le simulateur rend le moteur compréhensible sans installer Postman. Il permet de saisir une
+transaction synthétique, de charger trois scénarios, puis d'afficher le score et les raisons. Il
+n'est ni un portail bancaire ni une interface de revue humaine réelle.
+
+```mermaid
+flowchart LR
+    B[Navigateur] -->|même origine| W[Nginx public]
+    W -->|X-API-Key injectée| A[API privée]
+    A -->|décision explicable| W
+    W --> B
+    B -->|mémoire de l'onglet| H[Historique local, 20 entrées]
+```
+
+Le JavaScript du navigateur n'accède jamais à `API_KEY` ni à `LOAD_TEST_TOKEN`. Nginx écrase le
+premier avec le secret serveur. Il relaie un éventuel header de charge vers l'API, qui reste seule à
+connaître et comparer le secret hors production ; un token absent ou faux garde le plafond public.
+Aucun secret n'existe dans le bundle statique ou dans le DOM.
+
+## Parcours
+
+1. L'interface charge `GET /api/rules` et affiche la politique réellement active.
+2. L'utilisateur choisit un scénario ou saisit des valeurs.
+3. Une validation accessible signale tous les champs incorrects avant l'appel.
+4. `POST /api/decisions` reçoit une nouvelle `Idempotency-Key` et le payload EUR normalisé.
+5. La décision affiche verdict, score, raisons, mode, identifiant et instant d'évaluation.
+6. Le résultat rejoint un historique en mémoire, limité aux 20 entrées les plus récentes.
+
+`GET /api/decisions` n'est jamais appelé et n'existe pas. Un autre navigateur ou replica ne peut
+donc pas consulter l'historique de cet onglet.
+
+## Scénarios déterministes
+
+| Scénario               | Signaux principaux                                  | Résultat attendu |
+| ---------------------- | --------------------------------------------------- | ---------------- |
+| transaction habituelle | magasin, FR, montant faible, catégorie normale      | `APPROVED`       |
+| contexte à vérifier    | pays hors liste et achat en ligne                   | `REVIEW`         |
+| signaux cumulés        | pays, montant, catégorie sensible et achat en ligne | `REJECTED`       |
+
+La vélocité n'est pas utilisée pour fabriquer ces trois exemples : leur résultat reste donc
+compréhensible dès le premier clic. Des soumissions répétées permettent ensuite d'observer la règle
+de vélocité réelle.
+
+## États du service
+
+L'interface interroge `/ready` toutes les cinq secondes et observe `X-Instance-Id` sur les réponses.
+
+- **normal** : API prête et Redis disponible ;
+- **dégradé** : API prête, Redis indisponible, décision forcée à `REVIEW` ;
+- **indisponible** : readiness inaccessible ou non réussie.
+
+Le nombre de replicas affiché représente les identifiants observés pendant les 30 dernières
+secondes, pas une promesse sur la configuration Azure. Il sert de preuve pendant un test de charge.
+
+## Accessibilité et sécurité du rendu
+
+Les champs ont des labels, les erreurs sont reliées visuellement et le premier champ incorrect
+reçoit le focus. Les changements d'état et erreurs utilisent des régions `aria-live`. Le clavier, le
+contraste, le responsive et `prefers-reduced-motion` sont pris en compte.
+
+Les données de l'API sont toujours insérées avec `textContent`, jamais `innerHTML`. La page reçoit
+une CSP restrictive, des headers anti-frame/anti-sniff et `Cache-Control: no-store`.
+
+## Tests
+
+Les tests sans navigateur couvrent la normalisation, toutes les erreurs du formulaire, les trois
+scénarios, la limite et l'isolation de l'historique, les headers de soumission, l'absence de clé API
+côté client et les messages d'erreur. Les tests existants du suivi de replicas restent actifs.

--- a/docs/limites.md
+++ b/docs/limites.md
@@ -1,0 +1,36 @@
+# Limites et améliorations
+
+## Limites assumées
+
+| Limite                                 | Conséquence                                                  |
+| -------------------------------------- | ------------------------------------------------------------ |
+| heuristiques déterministes             | aucune prétention à détecter une fraude réelle               |
+| EUR uniquement                         | aucun taux de change ni politique multidevise                |
+| absence d’authentification utilisateur | la clé API protège seulement web → API                       |
+| absence de stockage métier durable     | décisions présentes dans la réponse et les logs d’audit      |
+| Redis unique par environnement         | état partagé temporaire, mais dépendance centrale            |
+| fenêtre de vélocité fixe               | modèle plus simple qu’une fenêtre glissante                  |
+| seuils au démarrage                    | modification par configuration et redéploiement              |
+| un seul fournisseur cloud              | IaC et runbooks Azure Container Apps                         |
+| environnement de charge limité         | résultats non extrapolables à une plateforme bancaire réelle |
+| maximum de dix replicas testé          | capacité bornée par l'abonnement étudiant                    |
+
+## Raisons
+
+La taille fonctionnelle reste compatible avec un test technique, tandis que les qualités
+d’ingénierie sont démontrables de bout en bout. Ajouter une base métier, un fournisseur d’identité,
+un moteur ML ou du multi-cloud masquerait les décisions importantes derrière du volume de code et ne
+rendrait pas la démonstration plus honnête.
+
+## Évolutions prioritaires
+
+1. persister une piste métier chiffrée avec politique de rétention et droit d’accès ;
+2. intégrer OIDC utilisateur et autorisations par rôle ;
+3. versionner dynamiquement les politiques de risque avec approbation et rollback ;
+4. utiliser un service Redis managé redondé avec rotation sans interruption ;
+5. ajouter WAF, private endpoints et limitation à l’ingress ;
+6. calibrer règles/seuils avec des données gouvernées et mesurer les faux positifs/négatifs ;
+7. tester régulièrement restauration, rotation, montée de version et reprise de région.
+
+Une amélioration future doit garder les garanties actuelles : explicabilité, idempotence,
+observabilité, tests de panne, artefacts immuables et quality gates bloquants.

--- a/docs/livraison.md
+++ b/docs/livraison.md
@@ -1,0 +1,143 @@
+# Livraison, promotion et rollback
+
+## Objectif
+
+La chaîne de livraison sépare la validation du code, la publication d'artefacts et leur promotion.
+Une image validée n'est jamais reconstruite entre l'intégration, la préproduction et la production.
+La preuve relie donc sans ambiguïté un commit, deux digests ACR et un déploiement.
+
+```mermaid
+flowchart LR
+    PR[PR vers develop] --> CI[CI complète]
+    CI --> Images[Images scannées]
+    Images --> ACR[Publication ACR par digest]
+    ACR --> Integration[Déploiement intégration]
+    Integration --> Manifest[Manifeste de promotion]
+    Manifest --> Preprod[release vers préproduction]
+    Preprod --> Production[main vers production]
+    Production --> Tag[Tag et GitHub Release]
+```
+
+## Responsabilité des workflows
+
+| Workflow                        | Déclencheur                    | Responsabilité                                                                  |
+| ------------------------------- | ------------------------------ | ------------------------------------------------------------------------------- |
+| `.github/workflows/ci.yml`      | PR et push sur branche durable | gouvernance, tests, quality gates, images, publication et choix de la promotion |
+| `.github/workflows/deploy.yml`  | appel réutilisable ou manuel   | déploiement par digest, smoke test et rollback                                  |
+| `.github/workflows/release.yml` | tag `v*.*.*`                   | validation du manifeste et création de la GitHub Release                        |
+
+Les permissions sont déclarées au plus près des jobs. `id-token: write` n'est accordé qu'aux jobs
+qui s'authentifient auprès d'Azure par OIDC. La création d'une GitHub Release est isolée du workflow
+réutilisable afin qu'elle seule reçoive `contents: write` ; un appel de déploiement ne peut donc pas
+augmenter silencieusement les droits transmis par la CI.
+
+## Parcours des artefacts
+
+### Intégration
+
+Sur un push accepté dans `develop`, la CI :
+
+1. construit les images API et web avec le SHA du commit ;
+2. contrôle leur utilisateur, leur configuration et leurs vulnérabilités avec Trivy ;
+3. empaquette exactement ces images dans un artefact temporaire ;
+4. recharge cet artefact sans nouvelle construction ;
+5. publie les images dans ACR et récupère leurs digests ;
+6. déploie ces digests en intégration ;
+7. exécute le smoke test et conserve la preuve de déploiement pendant 30 jours.
+
+L'artefact d'images n'est conservé qu'un jour : ACR devient ensuite la source des blobs immuables.
+
+### Préproduction et production
+
+La branche `release/vX.Y.Z` ajoute `.release/manifest.json`, à partir du candidat déjà validé en
+intégration. Le manifeste contient uniquement :
+
+```json
+{
+  "version": "v1.0.0",
+  "sourceSha": "0123456789abcdef0123456789abcdef01234567",
+  "apiImage": "registry.azurecr.io/transaction-risk-gate-api@sha256:<digest>",
+  "webImage": "registry.azurecr.io/transaction-risk-gate-web@sha256:<digest>",
+  "createdAt": "2026-09-01T12:00:00Z"
+}
+```
+
+La validation refuse un tag mutable, un registre différent, un SHA court ou un champ inattendu. Elle
+refuse aussi toute modification des contextes de construction `api/` et `web/` après le commit
+candidat : les digests ne pourraient plus représenter le code livré. Une correction de procédure,
+d'infrastructure ou de documentation reste possible à condition de franchir tous les Quality Gates ;
+elle ne modifie pas le contenu des images déjà scannées. `release/*` déploie le manifeste en
+préproduction ; `main` déploie exactement les mêmes digests en production. Le tag correspondant
+publie une GitHub Release qui rappelle le SHA et les deux digests.
+
+## Smoke test
+
+Le script `scripts/smoke/smoke-test.mjs` utilise uniquement Node.js et vérifie, avec des données
+synthétiques :
+
+- `/healthz` et `/ready` en mode normal avec Redis disponible ;
+- le contrat des cinq règles, la devise EUR et une somme des poids égale à 100 ;
+- une décision `APPROVED` ;
+- le rejeu idempotent avec le même `decisionId` ;
+- la présence de `X-Instance-Id`.
+
+Le script n'envoie jamais la clé interservice : il traverse le web public, qui l'injecte uniquement
+vers l'API privée. Hors `localhost`, il refuse une URL qui n'utilise pas HTTPS. Les tentatives sont
+bornées à 180 secondes afin d'absorber le démarrage d'une nouvelle révision sans masquer une panne.
+
+## Rollback
+
+Avant chaque déploiement, le workflow mémorise les révisions actives API et web. Si le smoke test du
+candidat échoue :
+
+1. le trafic est renvoyé à 100 % vers les deux révisions précédentes ;
+2. le smoke test est rejoué sur l'état restauré ;
+3. le workflow reste rouge, même si le service est de nouveau sain.
+
+Cette dernière règle empêche de présenter un candidat défaillant comme livré. Un opérateur peut
+aussi déclencher manuellement `deploy.yml`, sélectionner l'environnement et soit préciser les deux
+révisions, soit laisser `infra/rollback.sh` choisir les précédentes.
+
+## Configuration externe
+
+Les variables non sensibles restent au niveau du dépôt : noms Azure, région, registre, projet
+SonarCloud, organisation Snyk et URL publique. Les identifiants OIDC Azure, `SONAR_TOKEN` et
+`SNYK_TOKEN` sont des secrets du dépôt. Chaque GitHub Environment porte ses secrets runtime
+distincts :
+
+| Secret              | Intégration | Préproduction | Production |
+| ------------------- | :---------: | :-----------: | :--------: |
+| `API_KEY`           |     oui     |      oui      |    oui     |
+| `REDIS_HMAC_SECRET` |     oui     |      oui      |    oui     |
+| `REDIS_PASSWORD`    |     oui     |      oui      |    oui     |
+| `LOAD_TEST_TOKEN`   |     oui     |      oui      |    non     |
+
+L'absence volontaire de `LOAD_TEST_TOKEN` en production empêche le profil de charge privilégié sur
+l'environnement public. GitHub peut toutefois utiliser le secret du dépôt lorsqu'un secret portant
+le même nom est absent d'un Environment. Le workflow remplace donc explicitement cette valeur par
+une chaîne vide en production. Le script de déploiement refuse en plus toute valeur non vide : ces
+deux contrôles indépendants appliquent une défense en profondeur et bloquent le déploiement avant
+toute mutation Azure si la règle est contournée.
+
+Le projet SonarQube Cloud associé est `ghassenzaouali_transaction-risk-gate` et sa branche
+principale reste `main`. Avec l'offre Free, les PR vers chaque branche durable sont analysées et
+bloquées. Les pushes `develop` et `release/*` ne relancent pas une analyse multibranche indisponible
+dans cette offre : ils confirment la provenance du candidat. `main` reçoit l'analyse de branche
+principale et promeut le digest qui a déjà franchi les Quality Gates des PR.
+
+## Preuves et limites
+
+Chaque déploiement réussi produit un résumé GitHub et un fichier `deployment-evidence.json` avec
+l'environnement, la version, le SHA, les digests, l'URL, la date et le résultat du smoke test. Ces
+fichiers ne contiennent aucun secret.
+
+<!-- À COMPLÉTER en TRG-8/TRG-9, à partir des runs réels de ce dépôt. -->
+
+L'automatisation et ses tests locaux sont implémentés dans TRG-8. Consigner : le run CI qui publie
+les images par digest et déploie l'intégration, le run qui promeut les mêmes digests en
+préproduction depuis `release/*`, puis le run qui les déploie en production depuis `main` avec smoke
+test sur l'URL publique «`PUBLIC_BASE_URL`».
+
+La preuve production associe la version taguée au SHA source et aux digests immuables enregistrés
+dans `.release/manifest.json`. Un hotfix de procédure ne modifie ni `api/` ni `web/` et ne
+reconstruit donc pas les artefacts promus.

--- a/docs/metier.md
+++ b/docs/metier.md
@@ -1,0 +1,136 @@
+# Modèle métier de décision de risque
+
+## Finalité
+
+Transaction Risk Gate évalue une transaction synthétique avec cinq heuristiques déterministes. Il
+retourne un score, une décision et les règles déclenchées. Ce comportement est explicable et
+reproductible : les mêmes données, la même politique et le même contexte de vélocité produisent la
+même décision.
+
+Ce moteur démontre une architecture et des pratiques d’ingénierie. Il ne remplace pas un système
+antifraude réel, un modèle statistique, une obligation réglementaire ou une décision humaine.
+
+## Périmètre monétaire
+
+La première version accepte uniquement `EUR`. Un seuil de montant absolu n’a de sens que dans une
+devise connue. Accepter `USD`, `GBP` ou `CHF` avec le même nombre créerait des décisions
+incohérentes à cause des taux de change et des valeurs différentes.
+
+La frontière HTTP normalise `eur` en `EUR`, puis rejette toute autre devise. Une future prise en
+charge multidevise nécessiterait une source de taux, une date de valorisation, une politique de
+repli et des tests dédiés.
+
+## Règles et poids
+
+Les poids sont immuables dans cette version et totalisent exactement 100.
+
+| Règle                       |   Poids | Déclenchement                                         |
+| --------------------------- | ------: | ----------------------------------------------------- |
+| `VELOCITY`                  |      30 | compteur de la carte strictement supérieur au seuil   |
+| `COUNTRY_RISK`              |      25 | pays absent de la liste autorisée                     |
+| `AMOUNT_THRESHOLD`          |      20 | montant strictement supérieur au seuil EUR            |
+| `HIGH_RISK_MERCHANT`        |      15 | catégorie marchande présente dans la liste sensible   |
+| `CARD_NOT_PRESENT`          |      10 | canal `online`, donc carte non présentée physiquement |
+| **Risque maximal possible** | **100** | les cinq règles sont déclenchées                      |
+
+Les comparaisons strictes évitent les ambiguïtés de frontière : un montant égal au seuil ne
+déclenche pas `AMOUNT_THRESHOLD`, et un compteur égal au maximum autorisé ne déclenche pas
+`VELOCITY`.
+
+## Bandes de décision
+
+| Score  | Décision   | Interprétation de démonstration                 |
+| ------ | ---------- | ----------------------------------------------- |
+| 0–29   | `APPROVED` | aucune combinaison n’atteint le seuil de revue  |
+| 30–59  | `REVIEW`   | vérification humaine ou contrôle complémentaire |
+| 60–100 | `REJECTED` | risque heuristique élevé                        |
+
+Les bornes `0`, `29`, `30`, `59`, `60` et `100` sont testées directement. Le moteur refuse aussi un
+score hors de `0–100` : une telle valeur indique une erreur de programmation ou de politique, pas
+une décision valide.
+
+## Exemples
+
+### Transaction approuvée
+
+Une transaction en magasin, sous le seuil, dans un pays autorisé et une catégorie normale ne
+déclenche aucune règle : score `0`, décision `APPROVED`.
+
+### Transaction en revue
+
+Une quatrième transaction alors que `VELOCITY_MAX=3` déclenche `VELOCITY` : score `30`, décision
+`REVIEW`.
+
+### Transaction rejetée à la borne
+
+Un pays hors liste (`25`), un montant au-dessus du seuil (`20`) et une catégorie sensible (`15`)
+totalisent exactement `60` : décision `REJECTED`.
+
+```mermaid
+flowchart LR
+    Input[Transaction EUR validée] --> Context[Contexte de vélocité]
+    Context --> Rules[Cinq règles pures]
+    Rules --> Score[Somme de 0 à 100]
+    Score -->|0 à 29| Approved[APPROVED]
+    Score -->|30 à 59| Review[REVIEW]
+    Score -->|60 à 100| Rejected[REJECTED]
+```
+
+## Configuration active
+
+Les seuils et listes sont fournis au démarrage. Ils n’ont aucun défaut métier silencieux : une
+valeur absente ou invalide empêche l’application de démarrer.
+
+| Variable                        | Validation principale                  |
+| ------------------------------- | -------------------------------------- |
+| `AMOUNT_THRESHOLD`              | nombre EUR fini, `> 0`, maximum `10^9` |
+| `VELOCITY_MAX`                  | entier de `1` à `10 000`               |
+| `VELOCITY_WINDOW_SECONDS`       | entier de `1` à `3 600`                |
+| `ALLOWED_COUNTRIES`             | codes ISO alpha-2 uniques, non vides   |
+| `HIGH_RISK_MERCHANT_CATEGORIES` | identifiants normalisés uniques        |
+
+Les listes sont normalisées avant la détection des doublons. Par exemple, `FR,fr` est rejeté au lieu
+de créer deux entrées apparemment différentes.
+
+Les poids et bandes restent dans le code car ils constituent la version du modèle métier. Une
+modification exige donc tests, review éventuelle, traçabilité Git et nouvelle release. Les rendre
+dynamiques sans versionnement diminuerait la reproductibilité des décisions.
+
+## Confidentialité et explicabilité
+
+La réponse expose uniquement l’identifiant de décision, le verdict, le score, les noms de règles,
+leurs poids et une explication générique. Les explications ne répètent jamais :
+
+- `cardId` ou `transactionId` ;
+- montant exact ;
+- pays reçu ;
+- catégorie marchande reçue ;
+- payload complet.
+
+La piste d’audit structurée suit la même politique et ne conserve que la preuve de décision. Le
+contexte précis reste disponible pendant le traitement mais n’est pas recopié dans les logs.
+
+## Séparation des responsabilités
+
+`domain/risk-engine.ts` est pur : il ne connaît ni Fastify, ni Redis, ni horloge, ni réseau. Le cas
+d’usage `application/evaluate-transaction.ts` obtient le compteur de vélocité puis appelle le
+domaine. Cette séparation permet :
+
+- des tests rapides et exhaustifs des règles ;
+- l'utilisation de Redis sans coupler le calcul au stockage ;
+- une politique de mode dégradé explicite et testable ;
+- la preuve qu’une panne de dépendance ne fabrique pas silencieusement une approbation.
+
+Redis incrémente le compteur partagé avant l'évaluation. La quatrième transaction déclenche donc la
+règle lorsque `VELOCITY_MAX=3`, même si les quatre requêtes sont réparties entre plusieurs replicas.
+La carte n'est jamais utilisée directement comme clé : un HMAC-SHA-256 non réversible la
+pseudonymise. Le fonctionnement complet, les TTL et le mode dégradé sont décrits dans
+[Résilience et cohérence Redis](redis.md).
+
+## Limites actuelles
+
+- Les règles sont heuristiques et non calibrées sur des données réelles.
+- La fenêtre de vélocité est fixe, pas glissante.
+- Redis conserve uniquement un état technique temporaire ; aucune piste métier durable n'est créée.
+- Les seuils sont configurables au démarrage, mais pas modifiables dynamiquement.
+- Aucune décision n’est conservée dans une base métier durable.

--- a/docs/plateforme-azure.md
+++ b/docs/plateforme-azure.md
@@ -1,0 +1,131 @@
+# Plateforme conteneurisée et Azure
+
+## Séparation entre plateforme et livraison
+
+Le provisionnement ne construit aucune image et ne déploie jamais `latest`. Deux templates Bicep
+séparent les responsabilités :
+
+| Template                  | Responsabilité                                                                    |
+| ------------------------- | --------------------------------------------------------------------------------- |
+| `infra/platform.bicep`    | ACR, Log Analytics, identité `AcrPull` et environnement Azure Container Apps      |
+| `infra/apps.bicep`        | Redis, API et web pour un environnement logique, depuis deux digests déjà publiés |
+| `infra/provision.sh`      | validation et déploiement idempotent de la plateforme                             |
+| `infra/deploy-apps.sh`    | validation des entrées et déploiement d’un environnement logique                  |
+| `infra/configure-oidc.sh` | bootstrap administrateur de la fédération GitHub–Azure                            |
+
+Cette séparation évite le problème classique « l’IaC crée ACR et tente immédiatement de tirer une
+image qui n’y existe pas encore ». TRG-8 publie une fois les images déjà scannées, récupère leurs
+digests puis appelle le second template sans reconstruction.
+
+## Environnements
+
+Une plateforme physique est mutualisée pour limiter le coût. Les données et secrets ne le sont pas :
+chaque environnement logique possède son propre trio Redis/API/web.
+
+| Git durable | GitHub Environment | Noms Container Apps, exemple                                    |
+| ----------- | ------------------ | --------------------------------------------------------------- |
+| `develop`   | `integration`      | `redis-integration`, `api-integration`, `web-integration`       |
+| `release/*` | `preproduction`    | `redis-preproduction`, `api-preproduction`, `web-preproduction` |
+| `main`/`v*` | `production`       | `redis`, `api`, `web`                                           |
+
+Le partage d’ACR, de Log Analytics et de l’environnement Container Apps est un compromis de coût.
+Une production réelle séparerait au minimum les groupes de ressources et idéalement les abonnements.
+
+Le SKU ACR Basic conserve un endpoint public authentifié : compte administrateur et pull anonyme
+sont désactivés, les workloads utilisent l’identité `AcrPull` et la CI pousse par OIDC. Un registre
+accessible uniquement par private endpoint nécessiterait ACR Premium et un réseau virtuel ; c’est
+une évolution de production, pas une garantie simulée ici.
+
+## Frontières réseau
+
+```mermaid
+flowchart LR
+    Internet -->|HTTPS| Web[Web public]
+    Web -->|HTTPS + X-API-Key| Api[API ingress interne]
+    Api -->|TCP interne + mot de passe| Redis[(Redis ingress interne)]
+    Api --> Logs[Log Analytics]
+    Web --> Logs
+```
+
+Seul le web déclare `external: true`. L’API utilise l’ingress HTTP interne avec redirection HTTP
+désactivée et Nginx appelle son FQDN en HTTPS. Redis utilise l’ingress TCP interne : les autres
+Container Apps du même environnement peuvent le joindre par son nom, mais aucun endpoint public
+n’est créé.
+
+Redis est volontairement un conteneur mono-replica sans persistance : il porte uniquement des TTL de
+vélocité et d’idempotence, pas une base métier durable. Un mot de passe fort est injecté comme
+secret et écrit dans un fichier temporaire `0600` avant le démarrage de Redis. Le mot de passe
+disparaît de l’environnement du processus. Cette option économique n’offre pas le SLA ni le
+chiffrement TLS d’un service managé ; Azure Managed Redis avec private endpoint est l’évolution
+recommandée pour une production bancaire réelle.
+
+## Images et exécution
+
+- les bases Node, Nginx unprivileged et Redis sont épinglées par digest ;
+- les images applicatives portent le SHA Git dans les labels OCI ;
+- Redis, l’API et le web s’exécutent avec des utilisateurs non-root ;
+- Compose retire toutes les capabilities, impose `no-new-privileges` et des filesystems en lecture
+  seule avec seulement `/tmp` en mémoire ;
+- `.dockerignore` exclut dépendances, rapports, tests et fichiers `.env` du contexte ;
+- `deploy-apps.sh` refuse toute référence ne finissant pas par `@sha256:<64 hex>` ;
+- les secrets sont uniquement des `secretRef` Container Apps, jamais des `ARG`, `ENV` d’image ou
+  outputs Bicep.
+
+La CI compile Bicep, valide Compose, construit les images et inspecte leur utilisateur et leur
+configuration avant Trivy.
+
+## OIDC et permissions
+
+Le tenant CESI interdit aux comptes étudiants de créer une App Registration. La fédération OIDC
+utilise donc une identité managée affectée par l'utilisateur, propre au dépôt, avec trois
+credentials fédérés créés de façon idempotente. Les sujets immuables incluent les identifiants
+GitHub de l'organisation et du dépôt :
+
+```text
+repo:ghassenzaouali@139699856/transaction-risk-gate@1352445451:environment:integration
+repo:ghassenzaouali@139699856/transaction-risk-gate@1352445451:environment:preproduction
+repo:ghassenzaouali@139699856/transaction-risk-gate@1352445451:environment:production
+```
+
+Le workflow déclare `permissions: id-token: write` et le GitHub Environment correspondant. Azure
+émet alors un jeton court ; aucun client secret permanent n’est stocké. L'identité de déploiement
+reçoit `Owner` **uniquement** sur le groupe de ressources `rg-transaction-risk-gate`, jamais sur
+l'abonnement : le pipeline provisionne la plateforme (ACR, Log Analytics, environnement Container
+Apps) puis crée l'attribution `AcrPull` de l'identité runtime, ce qui exige la gestion des
+attributions de rôle à ce périmètre. En production, `Role Based Access Control Administrator`
+assorti d'une condition limitant les rôles assignables à `AcrPull` remplacerait `Owner` (voir
+[limites](limites.md)). L'identité runtime distincte ne reçoit que `AcrPull` sur l'ACR.
+
+## Commandes reproductibles
+
+Prévisualiser puis appliquer la plateforme :
+
+```bash
+PROVISION_MODE=what-if bash infra/provision.sh
+PROVISION_MODE=apply bash infra/provision.sh
+```
+
+Prévisualiser un déploiement applicatif après publication des images :
+
+```bash
+STAGE=integration \
+API_IMAGE='registry.azurecr.io/transaction-risk-gate-api@sha256:<digest>' \
+WEB_IMAGE='registry.azurecr.io/transaction-risk-gate-web@sha256:<digest>' \
+API_KEY='<secret>' REDIS_HMAC_SECRET='<secret>' REDIS_PASSWORD='<64-128-hex>' \
+LOAD_TEST_TOKEN='<secret>' DEPLOY_MODE=what-if \
+bash infra/deploy-apps.sh
+```
+
+Les secrets d’exemple sont des placeholders et ne doivent jamais être ajoutés à l’historique du
+shell, aux logs ou au dépôt. En CI, ils proviendront des GitHub Environments.
+
+## État des preuves
+
+Dans TRG-7, les deux templates compilent avec Bicep, Compose est validé statiquement et les images
+sont reconstruites puis scannées dans la CI. TRG-8 ajoute publication ACR, déploiement OIDC, smoke
+tests, manifeste de promotion, preuve par digest et rollback.
+
+<!-- À COMPLÉTER en TRG-8, à partir des runs réels de ce dépôt : consigner le run CI qui confirme en
+     intégration la publication ACR, la connexion OIDC, le déploiement Bicep, la résolution de l'URL,
+     le smoke test et la preuve immuable ; puis les runs de promotion en préproduction et en
+     production, tous appuyés sur le même manifeste de candidat, sans reconstruction d'image. -->

--- a/docs/postman/cloud.postman_environment.json
+++ b/docs/postman/cloud.postman_environment.json
@@ -1,0 +1,14 @@
+{
+  "id": "0307ea79-d8a8-44a3-8c5c-0d126030cc34",
+  "name": "Transaction Risk Gate - cloud",
+  "values": [
+    {
+      "key": "baseUrl",
+      "value": "https://REPLACE-WITH-PUBLIC-BASE-URL.swedencentral.azurecontainerapps.io",
+      "type": "default",
+      "enabled": true
+    }
+  ],
+  "_postman_variable_scope": "environment",
+  "_postman_exported_using": "Postman/11"
+}

--- a/docs/postman/local.postman_environment.json
+++ b/docs/postman/local.postman_environment.json
@@ -1,0 +1,14 @@
+{
+  "id": "80fcaf27-aad9-4be6-aec3-8eac80e4dd7a",
+  "name": "Transaction Risk Gate - local",
+  "values": [
+    {
+      "key": "baseUrl",
+      "value": "http://localhost:8080",
+      "type": "default",
+      "enabled": true
+    }
+  ],
+  "_postman_variable_scope": "environment",
+  "_postman_exported_using": "Postman/11"
+}

--- a/docs/postman/transaction-risk-gate.postman_collection.json
+++ b/docs/postman/transaction-risk-gate.postman_collection.json
@@ -1,0 +1,210 @@
+{
+  "info": {
+    "_postman_id": "60f49bed-67b5-438e-a8f8-34e58f045411",
+    "name": "Transaction Risk Gate",
+    "description": "Démonstration via la passerelle web. OpenAPI reste le contrat de référence.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "event": [
+    {
+      "listen": "prerequest",
+      "script": {
+        "type": "text/javascript",
+        "exec": [
+          "if (!pm.collectionVariables.get('runId')) {",
+          "  pm.collectionVariables.set('runId', pm.variables.replaceIn('{{$guid}}'));",
+          "}"
+        ]
+      }
+    }
+  ],
+  "item": [
+    {
+      "name": "Opérations",
+      "item": [
+        {
+          "name": "Liveness web",
+          "request": { "method": "GET", "url": "{{baseUrl}}/healthz" },
+          "event": [
+            {
+              "listen": "test",
+              "script": { "exec": ["pm.test('HTTP 200', () => pm.response.to.have.status(200));"] }
+            }
+          ]
+        },
+        {
+          "name": "Readiness API",
+          "request": { "method": "GET", "url": "{{baseUrl}}/ready" },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('API prête', () => {",
+                  "  const body = pm.response.json();",
+                  "  pm.expect(pm.response.code).to.eql(200);",
+                  "  pm.expect(body.status).to.eql('ready');",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Règles actives",
+          "request": { "method": "GET", "url": "{{baseUrl}}/api/rules" },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Cinq règles EUR totalisent 100', () => {",
+                  "  const body = pm.response.json();",
+                  "  pm.expect(body.currency).to.eql('EUR');",
+                  "  pm.expect(body.rules).to.have.length(5);",
+                  "  pm.expect(body.rules.reduce((sum, rule) => sum + rule.weight, 0)).to.eql(100);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Décisions",
+      "item": [
+        {
+          "name": "APPROVED",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "Idempotency-Key", "value": "approved-{{runId}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"transactionId\": \"approved-{{runId}}\",\n  \"cardId\": \"approved-card-{{runId}}\",\n  \"amount\": 20,\n  \"currency\": \"EUR\",\n  \"country\": \"FR\",\n  \"channel\": \"in_store\",\n  \"merchantCategory\": \"grocery\"\n}"
+            },
+            "url": "{{baseUrl}}/api/decisions"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Décision APPROVED normale', () => {",
+                  "  const body = pm.response.json();",
+                  "  pm.expect(body.decision).to.eql('APPROVED');",
+                  "  pm.expect(body.degraded).to.eql(false);",
+                  "  pm.collectionVariables.set('approvedDecisionId', body.decisionId);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Rejeu idempotent",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "Idempotency-Key", "value": "approved-{{runId}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"transactionId\": \"approved-{{runId}}\",\n  \"cardId\": \"approved-card-{{runId}}\",\n  \"amount\": 20,\n  \"currency\": \"EUR\",\n  \"country\": \"FR\",\n  \"channel\": \"in_store\",\n  \"merchantCategory\": \"grocery\"\n}"
+            },
+            "url": "{{baseUrl}}/api/decisions"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Même decisionId', () => {",
+                  "  pm.expect(pm.response.json().decisionId).to.eql(pm.collectionVariables.get('approvedDecisionId'));",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Conflit idempotent",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "Idempotency-Key", "value": "approved-{{runId}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"transactionId\": \"approved-{{runId}}\",\n  \"cardId\": \"approved-card-{{runId}}\",\n  \"amount\": 21,\n  \"currency\": \"EUR\",\n  \"country\": \"FR\",\n  \"channel\": \"in_store\",\n  \"merchantCategory\": \"grocery\"\n}"
+            },
+            "url": "{{baseUrl}}/api/decisions"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": ["pm.test('Conflit HTTP 409', () => pm.response.to.have.status(409));"]
+              }
+            }
+          ]
+        },
+        {
+          "name": "REVIEW",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "Idempotency-Key", "value": "review-{{runId}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"transactionId\": \"review-{{runId}}\",\n  \"cardId\": \"review-card-{{runId}}\",\n  \"amount\": 20,\n  \"currency\": \"EUR\",\n  \"country\": \"US\",\n  \"channel\": \"online\",\n  \"merchantCategory\": \"grocery\"\n}"
+            },
+            "url": "{{baseUrl}}/api/decisions"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Décision REVIEW', () => pm.expect(pm.response.json().decision).to.eql('REVIEW'));"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "REJECTED",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "Idempotency-Key", "value": "rejected-{{runId}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"transactionId\": \"rejected-{{runId}}\",\n  \"cardId\": \"rejected-card-{{runId}}\",\n  \"amount\": 2000,\n  \"currency\": \"EUR\",\n  \"country\": \"US\",\n  \"channel\": \"in_store\",\n  \"merchantCategory\": \"gambling\"\n}"
+            },
+            "url": "{{baseUrl}}/api/decisions"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Décision REJECTED à 60+', () => pm.expect(pm.response.json().decision).to.eql('REJECTED'));"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/docs/redis.md
+++ b/docs/redis.md
@@ -1,0 +1,135 @@
+# Résilience et cohérence Redis
+
+## Rôle dans le système
+
+Redis est l'état temporaire commun à tous les replicas API. Il garantit trois propriétés qui
+seraient fausses avec une mémoire locale :
+
+1. toutes les instances voient la même vélocité pour une carte ;
+2. une demande rejouée ou envoyée simultanément n'est évaluée qu'une fois ;
+3. le rate limiting compte globalement les requêtes de tous les replicas.
+
+```mermaid
+flowchart LR
+    A1[API replica 1] --> R[(Redis privé)]
+    A2[API replica 2] --> R
+    A3[API replica 3] --> R
+    R --> V[Vélocité 60 s]
+    R --> I[Idempotence 24 h]
+    R --> L[Rate limiting partagé]
+```
+
+Redis n'héberge ni logs, ni piste d'audit, ni décision durable. Les clés expirent automatiquement.
+La persistance est désactivée dans l'environnement local de démonstration.
+
+## Protection des identifiants
+
+Un `cardId` ou une `Idempotency-Key` ne devient jamais une clé Redis en clair. Le service calcule un
+HMAC-SHA-256 avec `REDIS_HMAC_SECRET`, puis utilise uniquement cette empreinte. Contrairement à un
+hash simple, le HMAC empêche de retrouver un identifiant prévisible sans connaître le secret.
+
+Le secret contient au moins 32 caractères, reste dans le gestionnaire de secrets et n'est jamais
+journalisé. Sa rotation invalide l'état temporaire existant et doit donc tenir compte du TTL
+d'idempotence.
+
+## Vélocité atomique
+
+Une opération Lua unique incrémente le compteur et pose son expiration au premier accès. Deux
+requêtes simultanées ne peuvent donc pas perdre une incrémentation. La fenêtre est fixe : une
+transaction tardive ne prolonge pas le TTL initial.
+
+| Paramètre                  | Valeur initiale | Rôle                             |
+| -------------------------- | --------------: | -------------------------------- |
+| `VELOCITY_WINDOW_SECONDS`  |          `60 s` | durée du compteur partagé        |
+| `VELOCITY_MAX`             |             `3` | maximum avant la règle de risque |
+| `REDIS_COMMAND_TIMEOUT_MS` |        `250 ms` | budget d'une opération Redis     |
+
+## Idempotence distribuée
+
+Le client fournit `Idempotency-Key`. Le service conserve l'empreinte du payload, un verrou court et
+la réponse terminée.
+
+```mermaid
+sequenceDiagram
+    participant A as Requête A
+    participant B as Requête concurrente
+    participant R as Redis
+    participant E as Évaluation
+    A->>R: réserver clé et hash payload
+    R-->>A: verrou acquis
+    B->>R: réserver même clé et même hash
+    R-->>B: traitement en cours
+    A->>E: évaluer une seule fois
+    A->>R: réponse TTL 24 h et libération
+    B->>R: relire
+    R-->>B: même réponse, replayed=true
+```
+
+- même clé et même payload : réponse originale rejouée sans nouvelle vélocité ;
+- même clé et payload différent : `409 idempotency_conflict` ;
+- appels identiques concurrents : une seule évaluation, les autres attendent ;
+- échec de l'évaluation : verrou libéré pour permettre une nouvelle tentative ;
+- réponse : TTL initial de 24 heures ; verrou : TTL initial de 5 secondes.
+
+Des scripts Lua finalisent ou libèrent un verrou uniquement pour son propriétaire. Une instance ne
+peut pas effacer le verrou repris par une autre après expiration.
+
+## Panne et circuit breaker
+
+Redis a un timeout de 250 ms. Après trois erreurs, le circuit s'ouvre pendant 10 secondes. Une seule
+requête `HALF_OPEN` teste ensuite le rétablissement.
+
+```mermaid
+stateDiagram-v2
+    [*] --> CLOSED
+    CLOSED --> OPEN: 3 erreurs
+    OPEN --> HALF_OPEN: après 10 s
+    HALF_OPEN --> CLOSED: test réussi
+    HALF_OPEN --> OPEN: test échoué
+```
+
+Sans Redis, supposer une vélocité nulle pourrait approuver une transaction risquée. Retourner
+uniquement `503` serait sûr mais inutilement indisponible. La politique **fail-safe** choisie est :
+
+- décision forcée à `REVIEW` ;
+- score au moins égal à `30` ;
+- `degraded: true`, raison `RISK_CONTEXT_UNAVAILABLE` et header `X-Degraded-Mode: true` ;
+- aucune décision `APPROVED` lorsque l'état partagé est indisponible.
+
+`/health` reste à `200` car le processus fonctionne. `/ready` reste à `200` avec `status: degraded`
+car l'instance produit encore une décision sûre. Pendant l'arrêt gracieux, `/ready` passe à `503`.
+
+Le rate limiting utilise le même état partagé. En cas de panne, il bascule vers un compteur mémoire
+borné par replica : la protection reste active, mais sa portée globale est temporairement réduite.
+Cette situation incrémente `rate_limit_fallback_total` et accompagne le mode de décision dégradé.
+
+## Observabilité
+
+Les transitions du circuit et la perte ou le retour de Redis produisent des événements structurés
+sans payload ni identifiant bancaire. Les métriques dédiées sont :
+
+- `shared_state_errors_total` ;
+- `degraded_decisions_total` ;
+- `redis_circuit_transitions_total{from,to}`.
+- `rate_limit_fallback_total`.
+
+## Preuves automatisées
+
+Les tests unitaires couvrent circuit, timeout, single-flight, conflits, TTL et mode dégradé HTTP. La
+CI démarre un vrai Redis et vérifie aussi :
+
+- le compteur atomique partagé entre plusieurs stores ;
+- l'expiration réelle ;
+- la concurrence distribuée et le replay 24 heures ;
+- l'absence des identifiants bruts dans les clés.
+- le compteur de rate limiting partagé et pseudonymisé.
+
+Ces tests s'exécutent avec `REDIS_TEST_URL`. Ils sont explicitement sautés en local si Redis est
+absent, mais jamais dans la CI qui fournit systématiquement ce service.
+
+## Limites
+
+- La fenêtre fixe est volontairement plus simple qu'une fenêtre glissante.
+- Le mode dégradé ne remplace pas une véritable file de revue humaine.
+- Préserver les replays pendant une rotation HMAC demanderait une stratégie à deux clés.
+- Un déploiement réel impose Redis privé, TLS et authentification.

--- a/docs/securite.md
+++ b/docs/securite.md
@@ -1,0 +1,87 @@
+# Sécurité de l'API
+
+## Frontières de confiance
+
+```mermaid
+flowchart LR
+    U[Navigateur non fiable] -->|HTTPS| W[Web public / Nginx]
+    W -->|X-API-Key injectée| A[API privée Fastify]
+    A -->|TCP interne + mot de passe| R[(Redis privé)]
+    G[GitHub Actions] -->|OIDC| Z[Azure]
+```
+
+Le navigateur ne connaît jamais `X-API-Key`. Le serveur web l'injecte lors du proxy vers l'API
+privée. Cette clé authentifie un service, pas un utilisateur : elle ne fournit ni compte, ni rôle,
+ni consentement. L'API ne doit donc pas être exposée directement sur Internet.
+
+Les secrets sont injectés par GitHub/Azure, absents de l'image et du dépôt, puis masqués par la
+redaction des logs. Les clés sont comparées via SHA-256 et `timingSafeEqual`.
+
+Le Redis conteneurisé de cet exercice est isolé par l'ingress interne et authentifié, mais n'offre
+pas de TLS applicatif. Cette limite économique est déclarée ; une production bancaire utiliserait
+Azure Managed Redis avec TLS et private endpoint.
+
+## Validation et limites
+
+| Contrôle              | Politique initiale                                          |
+| --------------------- | ----------------------------------------------------------- |
+| corps HTTP            | JSON, maximum 16 KiB                                        |
+| identifiants métier   | schéma strict, longueurs bornées, champs inconnus refusés   |
+| `X-Request-Id`        | 1 à 64 caractères sûrs ; valeur invalide rejetée            |
+| `Idempotency-Key`     | 8 à 128 caractères sûrs ; conflit de payload en `409`       |
+| token de charge       | 32 à 256 caractères, interdit en production                 |
+| paramètres de requête | refusés sur le contrat v1                                   |
+| chemin                | segment limité à 64 caractères                              |
+| sockets               | timeouts explicites et 1 000 requêtes maximum par connexion |
+
+Un payload trop grand retourne `413`, une entrée incorrecte `400` et une clé interservice absente ou
+fausse `401`. Les messages ne répètent jamais les valeurs reçues.
+
+## Rate limiting
+
+Les routes `/api/*` sont limitées par adresse cliente observée. En cloud, un seul proxy de confiance
+est déclaré explicitement ; une chaîne arbitraire de proxies n'est jamais acceptée.
+
+- profil public : 60 requêtes par minute ;
+- profil de charge : jusqu’à 1 000 000 requêtes par minute avec `X-Load-Test-Token` valide ;
+- profil de charge disponible uniquement en intégration ou préproduction ;
+- `/health`, `/ready` et `/metrics` restent accessibles à la supervision.
+
+Le compteur est partagé dans Redis et sa clé IP est pseudonymisée par HMAC. Pendant une panne, une
+limite locale bornée reste active sur chaque replica. La protection n'est jamais désactivée ;
+`rate_limit_fallback_total` rend sa portée temporairement réduite visible. Une limitation à
+l'ingress reste recommandée comme défense supplémentaire.
+
+## Headers et données
+
+Les réponses imposent `Cache-Control: no-store`, `X-Content-Type-Options: nosniff`,
+`X-Frame-Options: DENY`, `Referrer-Policy: no-referrer` et une Content Security Policy restrictive.
+CORS n'est pas activé : le navigateur parle au web public, pas directement à l'API privée.
+
+Les logs n'incluent jamais corps, headers, `cardId`, `transactionId`, clés d'idempotence ou secrets.
+Une seconde barrière Pino de redaction est testée sur de vraies lignes JSON. Redis ne voit que les
+empreintes HMAC des identifiants.
+
+`GET /api/decisions` n'existe pas : une liste globale exposerait les résultats d'autres visiteurs et
+serait incohérente entre replicas. L'historique de démonstration restera dans la session du
+navigateur.
+
+## Menaces et réponses
+
+| Menace                       | Réponse                                                        |
+| ---------------------------- | -------------------------------------------------------------- |
+| brute force interservice     | rate limiting avant authentification, métrique et log de refus |
+| rejeu ou double soumission   | idempotence Redis et conflit `409`                             |
+| fuite d'identifiants         | HMAC Redis, logs génériques, tests de redaction                |
+| payload volumineux ou lent   | limite 16 KiB, timeouts et recyclage des sockets               |
+| falsification de corrélation | format strict de `X-Request-Id`                                |
+| panne Redis                  | circuit breaker, `REVIEW` fail-safe et limite locale de repli  |
+| secret Azure longue durée    | fédération OIDC GitHub vers Azure                              |
+| substitution d'artefact      | images scannées rechargées puis promotion par digest           |
+| candidat cloud défaillant    | smoke test, rollback automatique et workflow maintenu rouge    |
+
+## Limites assumées
+
+La v1 ne possède pas d'authentification utilisateur, de WAF ni de rotation dynamique des clés. L'API
+doit rester privée. La rotation sans interruption et une limitation globale à l'ingress sont des
+améliorations de production documentées, pas des garanties simulées.

--- a/docs/test-charge.md
+++ b/docs/test-charge.md
@@ -1,0 +1,105 @@
+# Tests de charge et scalabilité
+
+## Pourquoi ce test est obligatoire
+
+Le cahier des charges demande de simuler une augmentation du trafic et de montrer le comportement
+sous charge. Le test vérifie simultanément performance, autoscaling Azure et cohérence Redis entre
+replicas.
+
+## Profils k6
+
+| Profil     | Charge                           | Usage                  |
+| ---------- | -------------------------------- | ---------------------- |
+| `baseline` | 5 VU pendant 30 s                | référence courte       |
+| `scale`    | 0 → 5 → 50 → 150 → 0 VU en 3 min | autoscaling attendu    |
+| `stress`   | 0 → 50 → 150 → 300 → 0 en 3 min  | recherche de la limite |
+
+Le workflow manuel refuse la production. Un `LOAD_TEST_TOKEN` propre à l’environnement relève le
+plafond de rate limiting uniquement en intégration/préproduction. Le secret n’est ni journalisé ni
+envoyé au navigateur par l’application.
+
+## Contrats par profil
+
+Le taux d'erreur et les checks portent la même exigence sur les trois profils. La latence distingue
+en revanche l'objectif interactif de référence et les enveloppes sous saturation contrôlée :
+
+| Profil     | Erreurs HTTP | Checks | p95       | p99       | Interprétation                       |
+| ---------- | ------------ | ------ | --------- | --------- | ------------------------------------ |
+| `baseline` | `< 1 %`      | `>99%` | `<250ms`  | `<500ms`  | objectif interactif                  |
+| `scale`    | `< 1 %`      | `>99%` | `<750ms`  | `<1000ms` | autoscaling jusqu'à 150 VU           |
+| `stress`   | `< 1 %`      | `>99%` | `<1250ms` | `<1750ms` | caractérisation à 300 VU, pas un SLO |
+
+Les objectifs initiaux utilisaient `p95 < 250 ms` et `p99 < 500 ms` pour tous les profils. Le
+premier benchmark Azure a confirmé ces valeurs pour `baseline`. `scale` et `stress` ont conservé 0 %
+d'erreur, 100 % de checks et une cohérence Redis complète, mais ont franchi uniquement les seuils de
+latence initiaux. Les enveloppes ci-dessus ont donc été séparées par intention. Elles restent
+supérieures aux mesures avec une marge observable et ne transforment pas le stress en promesse de
+latence interactive.
+
+## Preuve multi-replica et Redis
+
+Après la charge, k6 envoie cent sondes et collecte `X-Instance-Id`. Les profils `scale` et `stress`
+échouent si moins de deux replicas sont observés. Huit transactions simultanées utilisent ensuite la
+même carte synthétique : avec `VELOCITY_MAX=3`, au moins cinq réponses doivent contenir la règle
+`VELOCITY`, quel que soit le replica ayant répondu.
+
+Le workflow conserve pendant 30 jours : sortie k6, résumé métrique JSON, preuve JSON contenant
+replicas/p95/p99/taux d’erreur/vélocité et résumé lisible dans GitHub Actions.
+
+## Exécution
+
+Dans GitHub Actions, choisir **Tests de charge**, un environnement hors production et un profil. Une
+exécution locale est possible avec k6 2.2.0 :
+
+```powershell
+$env:PUBLIC_BASE_URL = "https://integration.example"
+$env:LOAD_TEST_TOKEN = "secret-hors-production"
+$env:LOAD_PROFILE = "baseline"
+k6 run scripts/load/load-test.js
+```
+
+## Résultats vérifiés localement
+
+<!-- À COMPLÉTER en TRG-9, à partir de l'exécution locale réelle. -->
+
+Baseline local (Docker Desktop, un seul replica API, k6 versionné) : consigner la durée, le nombre
+d'itérations et de requêtes, le débit moyen, le taux d'erreurs HTTP, le pourcentage de checks, p95,
+p99 et le nombre de déclenchements de vélocité sur huit transactions partagées. Vérifier que tous
+les seuils `baseline` passent. Cette mesure prouve le script, le token de charge, la passerelle
+Nginx et la cohérence Redis locale ; elle ne prouve pas l'autoscaling Azure.
+
+## Résultats vérifiés sur Azure
+
+<!-- À COMPLÉTER en TRG-9, à partir des exécutions k6 réelles contre l'intégration puis la
+     préproduction déployées par la CI de ce dépôt. -->
+
+Pour chaque profil, consigner : SHA source, run CI de déploiement préalable, requêtes, débit,
+erreurs, checks, p95, p99 et nombre de replicas API observés. Vérifier que `scale` et `stress`
+atteignent au moins deux replicas et que la série de huit transactions synchrones déclenche au moins
+cinq règles `VELOCITY` quel que soit le replica répondant — preuve que Redis conserve une vision
+commune de la carte malgré la distribution du trafic.
+
+| Profil     | Requêtes | Débit | Erreurs | Checks | p95 | p99 | Replicas API |
+| ---------- | -------: | ----: | ------: | -----: | --: | --: | -----------: |
+| `baseline` |        — |     — |       — |      — |   — |   — |            — |
+| `scale`    |        — |     — |       — |      — |   — |   — |            — |
+| `stress`   |        — |     — |       — |      — |   — |   — |            — |
+
+## Artefacts GitHub Actions officiels
+
+<!-- À COMPLÉTER en TRG-9 : rejouer les trois profils via le workflow « Tests de charge » depuis
+     release/* contre la préproduction. Chaque run produit un artefact 30 jours contenant k6.log,
+     k6-summary.json et load-evidence.json. -->
+
+| Profil     | Run GitHub Actions | Erreurs | Checks | p95 | p99 | Replicas | Vélocité |
+| ---------- | ------------------ | ------: | -----: | --: | --: | -------: | -------: |
+| `baseline` | [`—`][1]           |       — |      — |   — |   — |        — |      —/8 |
+| `scale`    | [`—`][2]           |       — |      — |   — |   — |        — |      —/8 |
+| `stress`   | [`—`][3]           |       — |      — |   — |   — |        — |      —/8 |
+
+Les artefacts bruts téléchargés pour vérification restent ignorés par Git. La documentation ne
+retient que les métriques stables, les identifiants de runs et l'interprétation reproductible.
+
+[1]: https://github.com/ghassenzaouali/transaction-risk-gate/actions/runs/REMPLACER-baseline
+[2]: https://github.com/ghassenzaouali/transaction-risk-gate/actions/runs/REMPLACER-scale
+[3]: https://github.com/ghassenzaouali/transaction-risk-gate/actions/runs/REMPLACER-stress

--- a/docs/test-panne.md
+++ b/docs/test-panne.md
@@ -1,0 +1,49 @@
+# Tests de panne et rétablissement
+
+## Panne Redis locale
+
+Avec la stack Compose démarrée :
+
+```powershell
+node scripts/failure/redis-outage.mjs
+```
+
+Le runbook :
+
+1. arrête uniquement Redis ;
+2. soumet une transaction normalement approuvable ;
+3. exige HTTP 200, `REVIEW`, score au moins 30, `degraded: true`, header `X-Degraded-Mode: true` et
+   raison `RISK_CONTEXT_UNAVAILABLE` ;
+4. redémarre Redis même si une assertion échoue ;
+5. attend la sonde half-open du circuit breaker ;
+6. exige une nouvelle décision `APPROVED`, non dégradée ;
+7. confirme `/ready` en mode normal avec Redis disponible.
+
+Cette politique est fail-safe : une information de vélocité inconnue ne devient jamais une
+approbation. Le service reste utile pour une revue manuelle au lieu de répondre
+systématiquement 503.
+
+## Rollback de déploiement
+
+Avant une nouvelle révision, le workflow capture les révisions API et web actives. Si le smoke test
+du candidat échoue, il remet 100 % du trafic sur les deux révisions précédentes, rejoue le smoke et
+conserve le workflow en échec. Une restauration saine ne transforme donc jamais un candidat rouge en
+livraison réussie.
+
+Le workflow `Déploiement` permet aussi un rollback manuel vers des révisions explicites ou vers les
+précédentes. Cette action cible un environnement GitHub protégé et utilise Azure OIDC.
+
+## Résultats vérifiés
+
+<!-- À COMPLÉTER en TRG-9, à partir des exécutions réelles de ce dépôt. -->
+
+Panne Redis locale (`node scripts/failure/redis-outage.mjs`) : consigner la décision dégradée
+observée (`REVIEW`, score au moins 30, `degraded: true`), la décision rétablie (`APPROVED`) et la
+readiness finale (`normal`).
+
+Rollback de déploiement : consigner le [run du rollback][1] réel en intégration (bascule du trafic
+vers les révisions précédentes, smoke test rejoué, workflow maintenu en échec) puis le [run de
+restauration][2] explicite des révisions courantes. La production n'est jamais ciblée.
+
+[1]: https://github.com/ghassenzaouali/transaction-risk-gate/actions/runs/REMPLACER-rollback
+[2]: https://github.com/ghassenzaouali/transaction-risk-gate/actions/runs/REMPLACER-restauration

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -1,0 +1,55 @@
+# Stratégie de tests
+
+## Objectif
+
+Les tests cherchent à prouver le comportement métier, les frontières de sécurité et la capacité à
+exploiter le service. Un pourcentage seul ne suffit pas : chaque risque important possède un niveau
+de test adapté.
+
+## Pyramide appliquée
+
+| Niveau                 | Exemples                                                      |
+| ---------------------- | ------------------------------------------------------------- |
+| domaine unitaire       | cinq règles, bornes 29/30 et 59/60, score maximal, EUR        |
+| application            | compteur de vélocité injecté, mode fail-safe                  |
+| API par injection      | validation, auth, idempotence, concurrence, headers, limites  |
+| intégration Redis réel | Lua atomique, TTL, HMAC, single-flight, rate limiting partagé |
+| web                    | scénarios, rendu, historique de session, suivi des replicas   |
+| cycle de vie           | readiness, métriques, redaction, SIGTERM et drainage          |
+| conteneur              | non-root, read-only, health checks, Compose                   |
+| cloud                  | smoke, promotion par digest, charge, panne et rollback        |
+
+## Couverture
+
+La CI impose au moins 80 % pour l’API et le web, en incluant tous les fichiers de production. Le
+domaine métier possède une cible renforcée de 90 %. Les exclusions Sonar sont limitées aux points de
+composition et serveurs locaux sans logique métier.
+
+Dernière mesure locale vérifiée avant TRG-9 :
+
+| Périmètre |  Lignes | Branches |
+| --------- | ------: | -------: |
+| API       | 95,29 % |  89,93 % |
+| domaine   | 99,20 % |  96,42 % |
+| web       | 99,51 % |  86,23 % |
+
+Les quality gates ne sont jamais assouplis pour accepter un changement. Une baisse exige du code
+testé ou une justification d’exclusion ciblée et revue.
+
+## Contrôles négatifs
+
+Les suites couvrent notamment : devise autre que EUR, champs supplémentaires, content type
+incorrect, payload trop grand, clé API absente, mauvais request id, conflit d’idempotence, requêtes
+concurrentes, Redis lent ou indisponible, circuit ouvert, fuite dans les logs et arrêt forcé.
+
+## Preuves externes
+
+- SonarCloud vérifie bugs, vulnérabilités, hotspots, duplication et couverture ;
+- Snyk Open Source et Code bloquent les risques `HIGH` ou supérieurs ;
+- Gitleaks refuse les secrets ;
+- Trivy refuse les vulnérabilités `HIGH` et `CRITICAL` des images ;
+- smoke tests vérifient santé, Redis, règles, décision et rejeu après déploiement ;
+- k6 produit un résumé JSON et une preuve des replicas/vélocité comme artefacts GitHub.
+
+Les résultats de charge ne sont consignés qu’après une exécution réelle, jamais estimés depuis le
+code.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1387 @@
+{
+  "name": "transaction-risk-gate-tooling",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "transaction-risk-gate-tooling",
+      "version": "0.1.0",
+      "devDependencies": {
+        "markdownlint-cli2": "0.23.2",
+        "prettier": "3.9.6"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/katex": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
+      "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.3.tgz",
+      "integrity": "sha512-XKv5nnLs6nLF71NgiKJLIZFLkPyIEuOselLG7ujZnGrRfQK8HpvY+WqKhAJUAdLomwVHErVS4LfxFlPq0/FTAw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/globby": {
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-16.2.2.tgz",
+      "integrity": "sha512-NLvV9ubZ6NDsJaOpKPy3cQeJpKi9DcWiyCiFUpJPA0YihRqiE6RWaLUmgNNPr8MgPpLZjnBjSmou7uZBRJv9wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "fast-glob": "^3.3.3",
+        "ignore": "^7.0.5",
+        "is-path-inside": "^4.0.0",
+        "slash": "^5.1.0",
+        "unicorn-magic": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.8.tgz",
+      "integrity": "sha512-YYNsSlXBjMk92SKnkwvB5LOVSa6OznlFUGcsvrFgNJbJCd0M1XKeFVRc8ZByeCqz32FivYNHJVooLmdqrmvp/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.2.tgz",
+      "integrity": "sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.mjs"
+      }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsonpointer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "dev": true,
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/linkify-it": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
+    "node_modules/markdown-it": {
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
+      "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.5.0",
+        "linkify-it": "^5.0.2",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdownlint": {
+      "version": "0.41.1",
+      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.41.1.tgz",
+      "integrity": "sha512-qHKeU2E1bdyNAT077go2FVTNXvYcktN5IHtF6XyeD1l0PClxzSp2tUApAV14ORI8DGX4H9bNKZEzelZp4qn8IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "micromark": "4.0.2",
+        "micromark-core-commonmark": "2.0.3",
+        "micromark-extension-directive": "4.0.0",
+        "micromark-extension-gfm-autolink-literal": "2.1.0",
+        "micromark-extension-gfm-footnote": "2.1.0",
+        "micromark-extension-gfm-table": "2.1.1",
+        "micromark-extension-math": "3.1.0",
+        "micromark-util-types": "2.0.2",
+        "string-width": "8.2.1"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/DavidAnson"
+      }
+    },
+    "node_modules/markdownlint-cli2": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli2/-/markdownlint-cli2-0.23.2.tgz",
+      "integrity": "sha512-eUhcnkSpzURo/o4htSqc7LPDszgOOTknhU4eY/sPHvMCLxnTCYscv1gw1/js/idmaZPisv9ECVEIORcllqjTUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "globby": "16.2.2",
+        "js-yaml": "5.2.2",
+        "jsonc-parser": "3.3.1",
+        "jsonpointer": "5.0.1",
+        "markdown-it": "14.3.0",
+        "markdownlint": "0.41.1",
+        "markdownlint-cli2-formatter-default": "0.0.6",
+        "micromatch": "4.0.8",
+        "smol-toml": "1.7.0"
+      },
+      "bin": {
+        "markdownlint-cli2": "markdownlint-cli2-bin.mjs"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/DavidAnson"
+      }
+    },
+    "node_modules/markdownlint-cli2-formatter-default": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli2-formatter-default/-/markdownlint-cli2-formatter-default-0.0.6.tgz",
+      "integrity": "sha512-VVDGKsq9sgzu378swJ0fcHfSicUnMxnL8gnLm/Q4J/xsNJ4e5bA6lvAz7PCzIl0/No0lHyaWdqVD2jotxOSFMQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/DavidAnson"
+      },
+      "peerDependencies": {
+        "markdownlint-cli2": ">=0.0.4"
+      }
+    },
+    "node_modules/mdurl": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.1.0.tgz",
+      "integrity": "sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-directive": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-directive/-/micromark-extension-directive-4.0.0.tgz",
+      "integrity": "sha512-/C2nqVmXXmiseSSuCdItCMho7ybwwop6RrrRPk0KbOHW21JKoCldC+8rFOaundDoRBUWBnJJcxeA/Kvi34WQXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "parse-entities": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-math": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-3.1.0.tgz",
+      "integrity": "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/katex": "^0.16.0",
+        "devlop": "^1.0.0",
+        "katex": "^0.16.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/slash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/smol-toml": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.0.tgz",
+      "integrity": "sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
+      "integrity": "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "transaction-risk-gate-tooling",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=22"
+  },
+  "scripts": {
+    "docs:lint": "markdownlint-cli2",
+    "format:check": "prettier --check --ignore-unknown .",
+    "format:write": "prettier --write --ignore-unknown .",
+    "governance:check": "node scripts/governance/validate-repository.mjs",
+    "governance:test": "node --test scripts/governance/tests/git-policy.test.mjs",
+    "operations:test": "node --test scripts/smoke/smoke-test.test.mjs scripts/release/manifest.test.mjs scripts/load/config.test.mjs scripts/load/evidence.test.mjs scripts/failure/redis-outage.test.mjs"
+  },
+  "devDependencies": {
+    "markdownlint-cli2": "0.23.2",
+    "prettier": "3.9.6"
+  }
+}

--- a/scripts/dev/bootstrap-hooks.ps1
+++ b/scripts/dev/bootstrap-hooks.ps1
@@ -1,0 +1,91 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = "Stop"
+
+$RepositoryRoot = (git rev-parse --show-toplevel).Trim()
+$VirtualEnvironment = Join-Path $RepositoryRoot ".local\tools\pre-commit"
+$Python = Join-Path $VirtualEnvironment "Scripts\python.exe"
+$PreCommit = Join-Path $VirtualEnvironment "Scripts\pre-commit.exe"
+$env:PRE_COMMIT_HOME = Join-Path $RepositoryRoot ".local\cache\pre-commit"
+
+$Npm = Get-Command npm -ErrorAction SilentlyContinue
+if (-not $Npm) {
+    throw "Node.js 22 or newer and npm are required to install project tooling."
+}
+
+& $Npm.Source ci --ignore-scripts
+if ($LASTEXITCODE -ne 0) {
+    throw "Failed to install pinned project tooling."
+}
+
+function Test-PythonRuntime {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Executable
+    )
+
+    if (-not (Test-Path -LiteralPath $Executable)) {
+        return $false
+    }
+
+    try {
+        & $Executable -c "import encodings, sys, venv; raise SystemExit(0 if sys.version_info >= (3, 11) else 1)" *> $null
+        return $LASTEXITCODE -eq 0
+    }
+    catch {
+        return $false
+    }
+}
+
+if (-not (Test-PythonRuntime -Executable $Python)) {
+    $Candidates = @(
+        (Join-Path $env:LOCALAPPDATA "Programs\Python\Python313\python.exe"),
+        (Join-Path $env:LOCALAPPDATA "Programs\Python\Python312\python.exe"),
+        (Join-Path $env:LOCALAPPDATA "Programs\Python\Python311\python.exe"),
+        "C:\Python313\python.exe",
+        "C:\Python312\python.exe",
+        "C:\Python311\python.exe"
+    )
+
+    $PythonCommand = Get-Command python -ErrorAction SilentlyContinue
+    if ($PythonCommand) {
+        $Candidates += $PythonCommand.Source
+    }
+
+    $SelectedPython = $Candidates |
+        Select-Object -Unique |
+        Where-Object { $_ -and (Test-PythonRuntime -Executable $_) } |
+        Select-Object -First 1
+
+    if (-not $SelectedPython) {
+        throw "Python 3.11 or newer is required to install project-local hooks."
+    }
+
+    & $SelectedPython -m venv --clear $VirtualEnvironment
+    if ($LASTEXITCODE -ne 0 -or -not (Test-Path -LiteralPath $Python)) {
+        throw "Failed to create the project-local pre-commit environment."
+    }
+}
+
+& $Python -m pip install --disable-pip-version-check --upgrade "pip==26.2"
+if ($LASTEXITCODE -ne 0) {
+    throw "Failed to install the pinned pip version."
+}
+
+& $Python -m pip install --disable-pip-version-check "pre-commit==4.6.0"
+if ($LASTEXITCODE -ne 0) {
+    throw "Failed to install pre-commit 4.6.0."
+}
+
+& $PreCommit install-hooks
+if ($LASTEXITCODE -ne 0) {
+    throw "Failed to initialize the hook environments."
+}
+
+git config --local core.hooksPath .githooks
+if ($LASTEXITCODE -ne 0) {
+    throw "Failed to configure the repository-owned Git hooks."
+}
+
+Write-Host "Transaction Risk Gate hooks initialized."

--- a/scripts/dev/bootstrap-hooks.sh
+++ b/scripts/dev/bootstrap-hooks.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env sh
+set -eu
+
+repository_root="$(git rev-parse --show-toplevel)"
+virtual_environment="${repository_root}/.local/tools/pre-commit"
+python="${virtual_environment}/bin/python"
+pre_commit="${virtual_environment}/bin/pre-commit"
+export PRE_COMMIT_HOME="${repository_root}/.local/cache/pre-commit"
+
+if ! command -v npm >/dev/null 2>&1; then
+  printf '%s\n' "Node.js 22 or newer and npm are required to install project tooling." >&2
+  exit 1
+fi
+
+npm ci --ignore-scripts
+
+if [ ! -x "${python}" ]; then
+  python_command=""
+  for candidate in python3.13 python3.12 python3.11 python3; do
+    if command -v "${candidate}" >/dev/null 2>&1 && \
+      "${candidate}" -c 'import sys, venv; raise SystemExit(0 if sys.version_info >= (3, 11) else 1)' 2>/dev/null; then
+      python_command="${candidate}"
+      break
+    fi
+  done
+
+  if [ -z "${python_command}" ]; then
+    printf '%s\n' "Python 3.11 or newer is required to install project-local hooks." >&2
+    exit 1
+  fi
+
+  "${python_command}" -m venv --clear "${virtual_environment}"
+fi
+
+"${python}" -m pip install --disable-pip-version-check --upgrade 'pip==26.2'
+"${python}" -m pip install --disable-pip-version-check 'pre-commit==4.6.0'
+"${pre_commit}" install-hooks
+git config --local core.hooksPath .githooks
+
+printf '%s\n' "Transaction Risk Gate hooks initialized."

--- a/scripts/failure/redis-outage.mjs
+++ b/scripts/failure/redis-outage.mjs
@@ -1,0 +1,112 @@
+import { execFileSync } from "node:child_process";
+import process from "node:process";
+import { pathToFileURL } from "node:url";
+import { randomUUID } from "node:crypto";
+
+const wait = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+function invariant(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function normalizeBaseUrl(value) {
+  const url = new URL(value);
+  invariant(
+    url.protocol === "https:" || ["127.0.0.1", "localhost"].includes(url.hostname),
+    "HTTPS est obligatoire hors localhost",
+  );
+  return url.toString().replace(/\/$/, "");
+}
+
+export function assertDegradedDecision(response, body) {
+  invariant(response.status === 200, `mode dégradé HTTP ${response.status}`);
+  invariant(response.headers.get("x-degraded-mode") === "true", "X-Degraded-Mode est absent");
+  invariant(body.decision === "REVIEW", "une panne Redis doit forcer REVIEW");
+  invariant(body.degraded === true, "la décision de panne doit être dégradée");
+  invariant(body.score >= 30, "le score dégradé doit atteindre le seuil REVIEW");
+  invariant(
+    body.reasons?.some((reason) => reason.rule === "RISK_CONTEXT_UNAVAILABLE"),
+    "la raison de contexte indisponible est absente",
+  );
+}
+
+export function assertRecoveredDecision(response, body) {
+  invariant(response.status === 200, `rétablissement HTTP ${response.status}`);
+  invariant(response.headers.get("x-degraded-mode") === null, "le header dégradé persiste");
+  invariant(body.decision === "APPROVED", "la transaction saine n'est plus APPROVED");
+  invariant(body.degraded === false, "la décision reste dégradée après rétablissement");
+}
+
+async function decision(baseUrl, suffix) {
+  const response = await fetch(`${baseUrl}/api/decisions`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Idempotency-Key": `failure-${suffix}`,
+      "X-Request-Id": `failure.${suffix}`,
+    },
+    body: JSON.stringify({
+      transactionId: `failure-${suffix}`,
+      cardId: `failure-card-${suffix}`,
+      amount: 20,
+      currency: "EUR",
+      country: "FR",
+      channel: "in_store",
+      merchantCategory: "grocery",
+    }),
+    signal: AbortSignal.timeout(10_000),
+  });
+  return { response, body: await response.json() };
+}
+
+function compose(...args) {
+  execFileSync("docker", ["compose", ...args], { stdio: "inherit" });
+}
+
+export async function runRedisOutage(rawBaseUrl, { timeoutMs = 45_000 } = {}) {
+  const baseUrl = normalizeBaseUrl(rawBaseUrl);
+  const runId = randomUUID();
+  let redisStopped = false;
+  try {
+    compose("stop", "redis");
+    redisStopped = true;
+    const degraded = await decision(baseUrl, `${runId}-degraded`);
+    assertDegradedDecision(degraded.response, degraded.body);
+
+    compose("start", "redis");
+    redisStopped = false;
+    const deadline = Date.now() + timeoutMs;
+    let recovered;
+    while (Date.now() < deadline) {
+      await wait(1_000);
+      const candidate = await decision(baseUrl, `${runId}-${Date.now()}`);
+      if (candidate.body.degraded === false) {
+        assertRecoveredDecision(candidate.response, candidate.body);
+        recovered = candidate;
+        break;
+      }
+    }
+    invariant(recovered, `Redis ne s'est pas rétabli en ${timeoutMs} ms`);
+
+    const readyResponse = await fetch(`${baseUrl}/ready`, { signal: AbortSignal.timeout(10_000) });
+    const ready = await readyResponse.json();
+    invariant(readyResponse.status === 200, `/ready HTTP ${readyResponse.status}`);
+    invariant(ready.mode === "normal", "/ready ne revient pas en mode normal");
+    invariant(ready.dependencies?.redis === "available", "/ready ne confirme pas Redis");
+
+    return Object.freeze({
+      event: "redis_failure_recovery_passed",
+      degradedDecision: degraded.body.decision,
+      degradedScore: degraded.body.score,
+      recoveredDecision: recovered.body.decision,
+      readyMode: ready.mode,
+    });
+  } finally {
+    if (redisStopped) compose("start", "redis");
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const baseUrl = process.env.PUBLIC_BASE_URL ?? process.argv[2] ?? "http://127.0.0.1:8080";
+  console.log(JSON.stringify(await runRedisOutage(baseUrl)));
+}

--- a/scripts/failure/redis-outage.test.mjs
+++ b/scripts/failure/redis-outage.test.mjs
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { assertDegradedDecision, assertRecoveredDecision } from "./redis-outage.mjs";
+
+const response = (status, headers = {}) => new Response("{}", { status, headers });
+
+test("valide la politique fail-safe pendant la panne", () => {
+  assert.doesNotThrow(() =>
+    assertDegradedDecision(response(200, { "X-Degraded-Mode": "true" }), {
+      decision: "REVIEW",
+      score: 30,
+      degraded: true,
+      reasons: [{ rule: "RISK_CONTEXT_UNAVAILABLE" }],
+    }),
+  );
+});
+
+test("refuse une approbation dégradée", () => {
+  assert.throws(
+    () =>
+      assertDegradedDecision(response(200, { "X-Degraded-Mode": "true" }), {
+        decision: "APPROVED",
+        score: 0,
+        degraded: true,
+        reasons: [],
+      }),
+    /forcer REVIEW/,
+  );
+});
+
+test("valide le retour à une décision normale", () => {
+  assert.doesNotThrow(() =>
+    assertRecoveredDecision(response(200), { decision: "APPROVED", degraded: false }),
+  );
+});

--- a/scripts/governance/lib/git-policy.mjs
+++ b/scripts/governance/lib/git-policy.mjs
@@ -1,0 +1,161 @@
+export const workBranchPattern =
+  /^(feat|fix|security|test|docs|refactor|ci|chore|hotfix)\/TRG-([1-9][0-9]*)-[a-z0-9]+(?:-[a-z0-9]+)*$/;
+export const releaseBranchPattern = /^release\/v([0-9]+)\.([0-9]+)\.([0-9]+)$/;
+export const automationBranchPattern = /^dependabot\/.+$/;
+
+export const typeLabels = new Set([
+  "type:feat",
+  "type:fix",
+  "type:security",
+  "type:test",
+  "type:docs",
+  "type:refactor",
+  "type:ci",
+  "type:chore",
+]);
+export const riskLabels = new Set(["risk:low", "risk:medium", "risk:high"]);
+export const releaseLabels = new Set(["release:required", "release:not-required"]);
+
+function countLabels(labels, allowed) {
+  return labels.filter((label) => allowed.has(label)).length;
+}
+
+export function branchIdentity(branch) {
+  const work = workBranchPattern.exec(branch);
+  if (work) {
+    return {
+      kind: work[1] === "hotfix" ? "hotfix" : "work",
+      type: work[1],
+      workItem: work[2],
+    };
+  }
+  const release = releaseBranchPattern.exec(branch);
+  if (release) {
+    return { kind: "release", version: `${release[1]}.${release[2]}.${release[3]}` };
+  }
+  if (automationBranchPattern.test(branch)) {
+    return { kind: "automation", workItem: "6" };
+  }
+  if (branch === "main" || branch === "develop") {
+    return { kind: "protected", branch };
+  }
+  return { kind: "invalid" };
+}
+
+export function expectedBaseBranch(identity) {
+  if (identity.kind === "hotfix" || identity.kind === "release") {
+    return "main";
+  }
+  if (identity.kind === "work" || identity.kind === "automation") {
+    return "develop";
+  }
+  return undefined;
+}
+
+export function validateBranchName(branch, { allowAutomation = true } = {}) {
+  const identity = branchIdentity(branch);
+  if (identity.kind === "invalid" || (!allowAutomation && identity.kind === "automation")) {
+    return [
+      `branch '${branch || "(detached)"}' must follow <class>/TRG-<number>-<kebab-case> or release/v<semver>`,
+    ];
+  }
+  return [];
+}
+
+function validateSubjectShape(subject) {
+  const failures = [];
+  if (subject.length > 72) {
+    failures.push(`subject is ${subject.length} characters; maximum is 72`);
+  }
+  if (subject.endsWith(".")) {
+    failures.push("subject must not end with a period");
+  }
+  return failures;
+}
+
+export function validateCommitMessage(message, branch) {
+  const normalized = message.replace(/\r\n/g, "\n").trimEnd();
+  const lines = normalized.split("\n");
+  const subject = lines[0] ?? "";
+
+  if (/^(Merge|Revert) /.test(subject)) {
+    return [];
+  }
+
+  const failures = validateSubjectShape(subject);
+  const identity = branchIdentity(branch);
+
+  if (identity.kind === "work" || identity.kind === "hotfix" || identity.kind === "automation") {
+    const humanPrefix = `[TRG-${identity.workItem}] `;
+    const automationPrefix = `[TRG-${identity.workItem}]: `;
+    const prefix =
+      identity.kind === "automation" && subject.startsWith(automationPrefix)
+        ? automationPrefix
+        : humanPrefix;
+    if (!subject.startsWith(prefix)) {
+      failures.push(`branch ${branch} requires commit prefix ${humanPrefix.trim()}`);
+    } else {
+      const summary = subject.slice(prefix.length);
+      if (!/^[a-zà-öø-ÿ0-9]/u.test(summary)) {
+        failures.push("commit summary must begin with a lowercase verb or a digit");
+      }
+    }
+  } else if (identity.kind === "protected" || identity.kind === "release") {
+    failures.push(`direct commits on ${branch} are forbidden; use a reviewed pull request`);
+  } else {
+    failures.push(...validateBranchName(branch, { allowAutomation: false }));
+  }
+
+  if (lines.length > 1) {
+    if (lines[1] !== "") {
+      failures.push("the optional body must be separated by one blank line");
+    }
+    for (const [index, line] of lines.slice(2).entries()) {
+      if (line !== "" && !line.startsWith("- ")) {
+        failures.push(`body line ${index + 3} must start with '- '`);
+      }
+    }
+  }
+
+  return [...new Set(failures)];
+}
+
+export function validatePullRequest({ title, head, base, labels }) {
+  const failures = validateSubjectShape(title);
+  const identity = branchIdentity(head);
+  failures.push(...validateBranchName(head));
+
+  const expectedBase = expectedBaseBranch(identity);
+  if (expectedBase && base !== expectedBase) {
+    failures.push(`branch ${head} must target ${expectedBase}, not ${base}`);
+  }
+
+  const titlePattern =
+    identity.kind === "automation"
+      ? /^\[TRG-([1-9][0-9]*)\](?::)? ([a-zà-öø-ÿ0-9].*)$/u
+      : /^\[TRG-([1-9][0-9]*)\] ([a-zà-öø-ÿ0-9].*)$/u;
+  const titleMatch = titlePattern.exec(title);
+  if (!titleMatch) {
+    failures.push("pull request title must follow [TRG-N] lowercase summary");
+  } else if (
+    (identity.kind === "work" || identity.kind === "hotfix" || identity.kind === "automation") &&
+    titleMatch[1] !== identity.workItem
+  ) {
+    failures.push(`pull request title must use TRG-${identity.workItem} from branch ${head}`);
+  }
+
+  if (countLabels(labels, typeLabels) !== 1) {
+    failures.push("pull request requires exactly one type:* label");
+  }
+  if (countLabels(labels, riskLabels) !== 1) {
+    failures.push("pull request requires exactly one risk:* label");
+  }
+  if (countLabels(labels, releaseLabels) !== 1) {
+    failures.push("pull request requires exactly one release:* label");
+  }
+  if (!labels.some((label) => label.startsWith("area:"))) {
+    failures.push("pull request requires at least one area:* label");
+  }
+
+  return [...new Set(failures)];
+}

--- a/scripts/governance/tests/git-policy.test.mjs
+++ b/scripts/governance/tests/git-policy.test.mjs
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  branchIdentity,
+  expectedBaseBranch,
+  validateBranchName,
+  validateCommitMessage,
+  validatePullRequest,
+} from "../lib/git-policy.mjs";
+
+test("accepts every supported short-lived branch class", () => {
+  for (const type of [
+    "feat",
+    "fix",
+    "security",
+    "test",
+    "docs",
+    "refactor",
+    "ci",
+    "chore",
+    "hotfix",
+  ]) {
+    assert.deepEqual(validateBranchName(`${type}/TRG-12-short-topic`), []);
+  }
+  assert.deepEqual(validateBranchName("release/v1.2.3"), []);
+});
+
+test("rejects malformed branch names", () => {
+  assert.notDeepEqual(validateBranchName("feature/TRG-1-topic"), []);
+  assert.notDeepEqual(validateBranchName("feat/TRG-0-topic"), []);
+  assert.notDeepEqual(validateBranchName("feat/TRG-1-Bad_Name"), []);
+});
+
+test("maps branches to the expected protected base", () => {
+  assert.equal(expectedBaseBranch(branchIdentity("feat/TRG-2-risk-engine")), "develop");
+  assert.equal(expectedBaseBranch(branchIdentity("release/v1.0.0")), "main");
+  assert.equal(expectedBaseBranch(branchIdentity("hotfix/TRG-10-production-fix")), "main");
+});
+
+test("requires the work item in commit subjects", () => {
+  assert.deepEqual(
+    validateCommitMessage("[TRG-2] implementer le moteur de risque", "feat/TRG-2-risk-engine"),
+    [],
+  );
+  assert.match(
+    validateCommitMessage("[TRG-3] implementer le moteur", "feat/TRG-2-risk-engine").join("\n"),
+    /TRG-2/,
+  );
+});
+
+test("accepts Dependabot generated subjects without weakening human branches", () => {
+  assert.deepEqual(
+    validateCommitMessage(
+      "[TRG-6]: bump zod from 4.5.2 to 4.5.4",
+      "dependabot/npm_and_yarn/api/develop/npm-production-7257b05964",
+    ),
+    [],
+  );
+  assert.match(
+    validateCommitMessage("[TRG-6]: contourner la convention", "ci/TRG-6-quality-gates").join("\n"),
+    /requires commit prefix/,
+  );
+});
+
+test("validates optional commit bodies", () => {
+  assert.deepEqual(
+    validateCommitMessage(
+      "[TRG-1] formaliser la gouvernance\n\n- ajouter les règles\n- documenter les contrôles",
+      "chore/TRG-1-project-governance",
+    ),
+    [],
+  );
+  assert.match(
+    validateCommitMessage(
+      "[TRG-1] formaliser la gouvernance\nbody without separator",
+      "chore/TRG-1-project-governance",
+    ).join("\n"),
+    /blank line/,
+  );
+});
+
+test("allows generated merge commits and blocks direct protected commits", () => {
+  assert.deepEqual(validateCommitMessage("Merge pull request #1 from branch", "develop"), []);
+  assert.match(validateCommitMessage("[TRG-1] commit direct", "develop").join("\n"), /forbidden/);
+});
+
+test("accepts a fully classified pull request", () => {
+  assert.deepEqual(
+    validatePullRequest({
+      title: "[TRG-4] securiser les frontières API",
+      head: "security/TRG-4-api-observability",
+      base: "develop",
+      labels: ["type:security", "risk:high", "area:api", "release:required"],
+    }),
+    [],
+  );
+});
+
+test("accepts a Dependabot generated pull request title", () => {
+  assert.deepEqual(
+    validatePullRequest({
+      title: "[TRG-6]: bump zod from 4.5.2 to 4.5.4",
+      head: "dependabot/npm_and_yarn/api/develop/npm-production-7257b05964",
+      base: "develop",
+      labels: ["type:chore", "risk:low", "area:quality", "release:not-required"],
+    }),
+    [],
+  );
+});
+
+test("rejects a pull request with mismatched identity and labels", () => {
+  const failures = validatePullRequest({
+    title: "[TRG-5] construire le simulateur",
+    head: "feat/TRG-4-api-observability",
+    base: "main",
+    labels: ["type:feat", "type:fix", "area:web"],
+  });
+  assert.ok(failures.some((failure) => failure.includes("target develop")));
+  assert.ok(failures.some((failure) => failure.includes("TRG-4")));
+  assert.ok(failures.some((failure) => failure.includes("exactly one type")));
+  assert.ok(failures.some((failure) => failure.includes("risk")));
+  assert.ok(failures.some((failure) => failure.includes("release")));
+});

--- a/scripts/governance/validate-commit-message.mjs
+++ b/scripts/governance/validate-commit-message.mjs
@@ -1,0 +1,27 @@
+import fs from "node:fs";
+import process from "node:process";
+import { execFileSync } from "node:child_process";
+import { validateCommitMessage } from "./lib/git-policy.mjs";
+
+const messagePath = process.argv[2];
+if (!messagePath || !fs.existsSync(messagePath)) {
+  console.error("Usage: node validate-commit-message.mjs <commit-message-file>");
+  process.exit(2);
+}
+
+const message = fs.readFileSync(messagePath, "utf8");
+const branch = (
+  process.env.TRG_VALIDATION_BRANCH ??
+  execFileSync("git", ["branch", "--show-current"], { encoding: "utf8" })
+).trim();
+const failures = validateCommitMessage(message, branch);
+
+if (failures.length > 0) {
+  console.error("Commit message validation failed:");
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log(`Commit message matches branch ${branch}.`);

--- a/scripts/governance/validate-pre-push.mjs
+++ b/scripts/governance/validate-pre-push.mjs
@@ -1,0 +1,80 @@
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { execFileSync } from "node:child_process";
+import { branchIdentity, validateBranchName } from "./lib/git-policy.mjs";
+
+function git(...args) {
+  return execFileSync("git", args, { encoding: "utf8" }).trim();
+}
+
+function run(command, args) {
+  execFileSync(command, args, {
+    cwd: git("rev-parse", "--show-toplevel"),
+    stdio: "inherit",
+  });
+}
+
+function runNpm(args) {
+  if (process.platform !== "win32") {
+    run("npm", args);
+    return;
+  }
+
+  const wrappers = execFileSync("where.exe", ["npm.cmd"], { encoding: "utf8" })
+    .split(/\r?\n/)
+    .filter(Boolean);
+  const npmCli = wrappers
+    .map((wrapper) => path.join(path.dirname(wrapper), "node_modules", "npm", "bin", "npm-cli.js"))
+    .find((candidate) => fs.existsSync(candidate));
+
+  if (!npmCli) {
+    throw new Error("npm-cli.js was not found next to an npm.cmd on PATH");
+  }
+  run(process.execPath, [npmCli, ...args]);
+}
+
+const branch = git("branch", "--show-current");
+const identity = branchIdentity(branch);
+const failures = validateBranchName(branch, { allowAutomation: false });
+
+if (identity.kind === "protected" || identity.kind === "release") {
+  failures.push(`direct push to protected reference '${branch}' is forbidden`);
+}
+
+let upstream = "";
+try {
+  upstream = execFileSync(
+    "git",
+    ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"],
+    { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
+  ).trim();
+} catch {
+  // A first push is valid when it explicitly sets the same-name upstream.
+}
+
+if (upstream && upstream !== `origin/${branch}`) {
+  failures.push(`branch tracks '${upstream}', expected 'origin/${branch}'`);
+}
+
+if (failures.length > 0) {
+  console.error("Pre-push validation failed:");
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+run("git", ["diff", "--check"]);
+runNpm(["run", "format:check"]);
+runNpm(["run", "docs:lint"]);
+run(process.execPath, ["scripts/governance/validate-repository.mjs"]);
+run(process.execPath, ["--test", "scripts/governance/tests/git-policy.test.mjs"]);
+
+if (process.env.TRG_SKIP_TESTS_PRE_PUSH !== "1") {
+  runNpm(["--prefix", "api", "run", "build"]);
+  runNpm(["--prefix", "api", "test"]);
+  runNpm(["--prefix", "web", "test"]);
+}
+
+console.log(`Pre-push validation passed for ${branch}.`);

--- a/scripts/governance/validate-pull-request.mjs
+++ b/scripts/governance/validate-pull-request.mjs
@@ -1,0 +1,62 @@
+import fs from "node:fs";
+import process from "node:process";
+import { validatePullRequest } from "./lib/git-policy.mjs";
+
+function readEvent() {
+  if (process.env.TRG_PR_EVENT_JSON) {
+    return JSON.parse(process.env.TRG_PR_EVENT_JSON);
+  }
+  if (!process.env.GITHUB_EVENT_PATH) {
+    return undefined;
+  }
+  return JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, "utf8"));
+}
+
+async function currentLabels(event) {
+  const fallback = (event.pull_request.labels ?? []).map((label) => label.name);
+  const token = process.env.GITHUB_TOKEN;
+  const repository = process.env.GITHUB_REPOSITORY;
+  if (!token || !repository || !event.number) {
+    return fallback;
+  }
+
+  const response = await fetch(
+    `https://api.github.com/repos/${repository}/issues/${event.number}`,
+    {
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    },
+  );
+  if (!response.ok) {
+    throw new Error(`GitHub labels request failed with HTTP ${response.status}`);
+  }
+  const issue = await response.json();
+  return issue.labels.map((label) => (typeof label === "string" ? label : label.name));
+}
+
+const event = readEvent();
+if (!event?.pull_request) {
+  console.log("Pull request validation skipped outside a pull_request event.");
+  process.exit(0);
+}
+
+const labels = await currentLabels(event);
+const failures = validatePullRequest({
+  title: event.pull_request.title,
+  head: event.pull_request.head.ref,
+  base: event.pull_request.base.ref,
+  labels,
+});
+
+if (failures.length > 0) {
+  console.error("Pull request governance failed:");
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log(`Pull request ${event.number} satisfies Transaction Risk Gate governance.`);

--- a/scripts/governance/validate-repository.mjs
+++ b/scripts/governance/validate-repository.mjs
@@ -1,0 +1,199 @@
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { execFileSync } from "node:child_process";
+
+const root = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+  encoding: "utf8",
+}).trim();
+const failures = [];
+
+const requiredFiles = [
+  ".editorconfig",
+  ".gitattributes",
+  ".github/actions/setup-bicep/action.yml",
+  ".github/CODEOWNERS",
+  ".github/dependabot.yml",
+  ".github/labeler.yml",
+  ".github/pull_request_template.md",
+  ".github/workflows/ci.yml",
+  ".github/workflows/deploy.yml",
+  ".github/workflows/load-test.yml",
+  ".github/workflows/release.yml",
+  ".githooks/commit-msg",
+  ".githooks/pre-commit",
+  ".githooks/pre-push",
+  ".githooks/run-pre-commit",
+  ".gitignore",
+  ".gitleaks.toml",
+  ".markdownlint-cli2.jsonc",
+  ".pre-commit-config.yaml",
+  ".prettierignore",
+  ".prettierrc.json",
+  ".release/README.md",
+  ".release/manifest.example.json",
+  ".sonarlint/connectedMode.json",
+  ".vscode/extensions.json",
+  ".vscode/settings.json",
+  "CONTRIBUTING.md",
+  "README.md",
+  "SECURITY.md",
+  "docs/README.md",
+  "docs/api/openapi.yaml",
+  "docs/architecture.md",
+  "docs/governance/definition-of-done.md",
+  "docs/governance/git-policy.md",
+  "docs/governance/quality-security-gates.md",
+  "docs/governance/release-policy.md",
+  "docs/livraison.md",
+  "docs/limites.md",
+  "docs/plateforme-azure.md",
+  "docs/postman/cloud.postman_environment.json",
+  "docs/postman/local.postman_environment.json",
+  "docs/postman/transaction-risk-gate.postman_collection.json",
+  "docs/test-charge.md",
+  "docs/test-panne.md",
+  "docs/tests.md",
+  "package-lock.json",
+  "package.json",
+  "scripts/dev/bootstrap-hooks.ps1",
+  "scripts/dev/bootstrap-hooks.sh",
+  "scripts/governance/lib/git-policy.mjs",
+  "scripts/governance/tests/git-policy.test.mjs",
+  "scripts/governance/validate-commit-message.mjs",
+  "scripts/governance/validate-pre-push.mjs",
+  "scripts/governance/validate-pull-request.mjs",
+  "scripts/governance/validate-repository.mjs",
+  "scripts/release/manifest.mjs",
+  "scripts/release/manifest.test.mjs",
+  "scripts/load/config.mjs",
+  "scripts/load/config.test.mjs",
+  "scripts/load/evidence.mjs",
+  "scripts/load/evidence.test.mjs",
+  "scripts/load/load-test.js",
+  "scripts/failure/redis-outage.mjs",
+  "scripts/failure/redis-outage.test.mjs",
+  "scripts/smoke/smoke-test.mjs",
+  "scripts/smoke/smoke-test.test.mjs",
+  "sonar-project.properties",
+  // infra/ (Bicep + runbooks) est ajouté à cette liste avec la tranche TRG-7.
+];
+
+for (const relativePath of requiredFiles) {
+  if (!fs.existsSync(path.join(root, relativePath))) {
+    failures.push(`missing required governance file: ${relativePath}`);
+  }
+}
+
+const ignoredDirectories = new Set([
+  ".git",
+  ".local",
+  ".scannerwork",
+  "artifacts",
+  "coverage",
+  "dist",
+  "node_modules",
+]);
+
+function walk(directory) {
+  const files = [];
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    if (entry.isDirectory() && ignoredDirectories.has(entry.name)) {
+      continue;
+    }
+    const absolutePath = path.join(directory, entry.name);
+    files.push(...(entry.isDirectory() ? walk(absolutePath) : [absolutePath]));
+  }
+  return files;
+}
+
+function repositoryPath(absolutePath) {
+  return path.relative(root, absolutePath).replaceAll("\\", "/");
+}
+
+function withoutFencedCode(markdown) {
+  return markdown.replace(/```[\s\S]*?```/g, "");
+}
+
+const allFiles = walk(root);
+const markdownFiles = allFiles.filter((file) => file.endsWith(".md"));
+for (const markdownFile of markdownFiles) {
+  const relativePath = repositoryPath(markdownFile);
+  const source = fs.readFileSync(markdownFile, "utf8");
+  const fenceCount = (source.match(/^```/gm) ?? []).length;
+  if (fenceCount % 2 !== 0) {
+    failures.push(`${relativePath}: unbalanced fenced code block`);
+  }
+
+  for (const match of withoutFencedCode(source).matchAll(/!?\[[^\]]*]\(([^)]+)\)/g)) {
+    let target = match[1].trim();
+    if (target.startsWith("<") && target.endsWith(">")) {
+      target = target.slice(1, -1);
+    }
+    target = target.split(/\s+"/, 1)[0];
+    if (!target || target.startsWith("#") || /^(?:https?:|mailto:|urn:|data:)/i.test(target)) {
+      continue;
+    }
+    const decodedTarget = decodeURIComponent(target.split("#", 1)[0]);
+    const resolvedTarget = path.resolve(path.dirname(markdownFile), decodedTarget);
+    if (!fs.existsSync(resolvedTarget)) {
+      failures.push(`${relativePath}: broken relative link '${target}'`);
+    }
+  }
+}
+
+const adrFiles = allFiles.filter((file) =>
+  /[\\/]docs[\\/]decisions[\\/]ADR-\d{3}-.+\.md$/.test(file),
+);
+const adrNumbers = new Map();
+for (const adrFile of adrFiles) {
+  const number = path.basename(adrFile).match(/^ADR-(\d{3})-/)?.[1];
+  const previous = adrNumbers.get(number);
+  if (previous) {
+    failures.push(
+      `duplicate ADR number ${number}: ${repositoryPath(previous)} and ${repositoryPath(adrFile)}`,
+    );
+  } else {
+    adrNumbers.set(number, adrFile);
+  }
+}
+
+const workflowDirectory = path.join(root, ".github", "workflows");
+if (fs.existsSync(workflowDirectory)) {
+  for (const workflow of fs.readdirSync(workflowDirectory)) {
+    if (!/\.ya?ml$/.test(workflow)) {
+      continue;
+    }
+    const relativePath = `.github/workflows/${workflow}`;
+    const source = fs.readFileSync(path.join(workflowDirectory, workflow), "utf8");
+    for (const [pattern, reason] of [
+      [/continue-on-error:\s*true/i, "mandatory jobs cannot continue on error"],
+      [/allow_failure:\s*true/i, "mandatory jobs cannot allow failure"],
+      [/permissions:\s*write-all/i, "write-all permissions are forbidden"],
+      [/pull_request_target:/i, "pull_request_target is forbidden"],
+    ]) {
+      if (pattern.test(source)) {
+        failures.push(`${relativePath}: ${reason}`);
+      }
+    }
+    for (const match of source.matchAll(/uses:\s*([^@\s]+)@([^\s#]+)/g)) {
+      const action = match[1];
+      const reference = match[2];
+      if (!action.startsWith("./") && !/^[a-f0-9]{40}$/.test(reference)) {
+        failures.push(`${relativePath}: action ${action} must use a full commit SHA`);
+      }
+    }
+  }
+}
+
+if (failures.length > 0) {
+  console.error("Repository policy validation failed:");
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log(
+  `Repository policy validation passed (${markdownFiles.length} Markdown files, ${adrFiles.length} ADRs).`,
+);

--- a/scripts/load/config.mjs
+++ b/scripts/load/config.mjs
@@ -1,0 +1,83 @@
+const profiles = Object.freeze({
+  baseline: Object.freeze({
+    executor: "constant-vus",
+    vus: 5,
+    duration: "30s",
+  }),
+  scale: Object.freeze({
+    executor: "ramping-vus",
+    startVUs: 0,
+    stages: Object.freeze([
+      Object.freeze({ duration: "30s", target: 5 }),
+      Object.freeze({ duration: "60s", target: 50 }),
+      Object.freeze({ duration: "60s", target: 150 }),
+      Object.freeze({ duration: "30s", target: 0 }),
+    ]),
+    gracefulRampDown: "15s",
+  }),
+  stress: Object.freeze({
+    executor: "ramping-vus",
+    startVUs: 0,
+    stages: Object.freeze([
+      Object.freeze({ duration: "30s", target: 50 }),
+      Object.freeze({ duration: "60s", target: 150 }),
+      Object.freeze({ duration: "60s", target: 300 }),
+      Object.freeze({ duration: "30s", target: 0 }),
+    ]),
+    gracefulRampDown: "15s",
+  }),
+});
+
+export const performanceTargets = Object.freeze({
+  baseline: Object.freeze({
+    errorRate: 0.01,
+    p95Ms: 250,
+    p99Ms: 500,
+    checkRate: 0.99,
+  }),
+  scale: Object.freeze({
+    errorRate: 0.01,
+    p95Ms: 750,
+    p99Ms: 1000,
+    checkRate: 0.99,
+  }),
+  stress: Object.freeze({
+    errorRate: 0.01,
+    p95Ms: 1250,
+    p99Ms: 1750,
+    checkRate: 0.99,
+  }),
+});
+
+export function createLoadOptions(profileName = "baseline") {
+  const profile = profiles[profileName];
+  if (!profile) {
+    throw new Error(`unknown load profile '${profileName}'`);
+  }
+  const targets = performanceTargets[profileName];
+
+  const scenario = {
+    ...profile,
+    ...(profile.stages === undefined
+      ? {}
+      : { stages: profile.stages.map((stage) => ({ ...stage })) }),
+    exec: "evaluateDecision",
+  };
+
+  // k6 complète cet objet à l'initialisation de chaque VU : il doit rester
+  // mutable même si les profils sources sont immuables.
+  return {
+    discardResponseBodies: false,
+    summaryTrendStats: ["avg", "min", "med", "max", "p(90)", "p(95)", "p(99)"],
+    scenarios: { decisions: scenario },
+    thresholds: {
+      http_req_failed: [`rate<${targets.errorRate}`],
+      http_req_duration: [`p(95)<${targets.p95Ms}`, `p(99)<${targets.p99Ms}`],
+      checks: [`rate>${targets.checkRate}`],
+    },
+  };
+}
+
+export function requiresMultipleReplicas(profileName) {
+  return profileName === "scale" || profileName === "stress";
+}

--- a/scripts/load/config.test.mjs
+++ b/scripts/load/config.test.mjs
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createLoadOptions, performanceTargets, requiresMultipleReplicas } from "./config.mjs";
+
+test("baseline reste un contrôle court et mesurable", () => {
+  const options = createLoadOptions("baseline");
+  assert.equal(options.scenarios.decisions.vus, 5);
+  assert.equal(options.scenarios.decisions.duration, "30s");
+  assert.deepEqual(options.thresholds.http_req_duration, ["p(95)<250", "p(99)<500"]);
+  assert.ok(options.summaryTrendStats.includes("p(99)"));
+  assert.equal(performanceTargets.baseline.errorRate, 0.01);
+});
+
+test("scale applique son enveloppe et impose plusieurs replicas", () => {
+  const options = createLoadOptions("scale");
+  assert.equal(options.scenarios.decisions.stages.at(-2).target, 150);
+  assert.deepEqual(options.thresholds.http_req_duration, ["p(95)<750", "p(99)<1000"]);
+  assert.equal(requiresMultipleReplicas("scale"), true);
+  assert.equal(requiresMultipleReplicas("baseline"), false);
+});
+
+test("stress caractérise la capacité avec une enveloppe explicite", () => {
+  const options = createLoadOptions("stress");
+  assert.equal(options.scenarios.decisions.stages.at(-2).target, 300);
+  assert.deepEqual(options.thresholds.http_req_duration, ["p(95)<1250", "p(99)<1750"]);
+  assert.equal(requiresMultipleReplicas("stress"), true);
+});
+
+test("un profil inconnu est refusé", () => {
+  assert.throws(() => createLoadOptions("production-surprise"), /unknown load profile/);
+});

--- a/scripts/load/evidence.mjs
+++ b/scripts/load/evidence.mjs
@@ -1,0 +1,47 @@
+import fs from "node:fs";
+import process from "node:process";
+import { pathToFileURL } from "node:url";
+
+export function buildEvidence(logSource, summary, profile) {
+  const line = logSource
+    .split(/\r?\n/)
+    .map((value) => value.trim())
+    .find((value) => value.includes("load_evidence"));
+  if (!line) throw new Error("load_evidence event is missing from k6 output");
+
+  const message = line.startsWith("{")
+    ? line
+    : JSON.parse(`"${line.match(/\bmsg="((?:\\.|[^"])*)"/)?.[1] ?? ""}"`);
+  const operational = JSON.parse(message);
+  if (!operational.replicaCheck || !operational.velocityCheck) {
+    throw new Error("replica or velocity evidence failed");
+  }
+
+  const metrics = summary.metrics ?? {};
+  return Object.freeze({
+    profile,
+    completedAt: operational.completedAt,
+    replicas: operational.replicas,
+    replicaCount: operational.replicaCount,
+    velocityReplicas: operational.velocityReplicas,
+    velocityTriggered: operational.velocityTriggered,
+    errorRate: metrics.http_req_failed?.values?.rate,
+    p95Ms: metrics.http_req_duration?.values?.["p(95)"],
+    p99Ms: metrics.http_req_duration?.values?.["p(99)"],
+    checksRate: metrics.checks?.values?.rate,
+  });
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const [logPath, summaryPath, outputPath, profile = "baseline"] = process.argv.slice(2);
+  if (!logPath || !summaryPath || !outputPath) {
+    throw new Error("usage: evidence.mjs <k6.log> <summary.json> <evidence.json> [profile]");
+  }
+  const evidence = buildEvidence(
+    fs.readFileSync(logPath, "utf8"),
+    JSON.parse(fs.readFileSync(summaryPath, "utf8")),
+    profile,
+  );
+  fs.writeFileSync(outputPath, `${JSON.stringify(evidence, null, 2)}\n`);
+  console.log(JSON.stringify({ event: "load_evidence_written", ...evidence }));
+}

--- a/scripts/load/evidence.test.mjs
+++ b/scripts/load/evidence.test.mjs
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildEvidence } from "./evidence.mjs";
+
+test("assemble une preuve de charge exploitable", () => {
+  const log = [
+    "progress",
+    JSON.stringify({
+      event: "load_evidence",
+      completedAt: "2026-09-01T00:00:00.000Z",
+      replicas: ["api-1", "api-2"],
+      replicaCount: 2,
+      velocityReplicas: ["api-1", "api-2"],
+      velocityTriggered: 5,
+      replicaCheck: true,
+      velocityCheck: true,
+    }),
+  ].join("\n");
+  const result = buildEvidence(
+    log,
+    {
+      metrics: {
+        http_req_failed: { values: { rate: 0.001 } },
+        http_req_duration: { values: { "p(95)": 120, "p(99)": 220 } },
+        checks: { values: { rate: 1 } },
+      },
+    },
+    "scale",
+  );
+  assert.equal(result.replicaCount, 2);
+  assert.equal(result.p95Ms, 120);
+  assert.equal(result.velocityTriggered, 5);
+});
+
+test("refuse une preuve opérationnelle rouge", () => {
+  const log = JSON.stringify({
+    event: "load_evidence",
+    replicas: ["api-1"],
+    replicaCheck: false,
+    velocityCheck: true,
+  });
+  assert.throws(() => buildEvidence(log, {}, "scale"), /evidence failed/);
+});
+
+test("lit le préfixe de log réellement émis par k6", () => {
+  const event = JSON.stringify({
+    event: "load_evidence",
+    completedAt: "2026-09-02T05:15:48.861Z",
+    replicas: ["api-1", "api-2"],
+    replicaCount: 2,
+    velocityReplicas: ["api-1", "api-2"],
+    velocityTriggered: 5,
+    replicaCheck: true,
+    velocityCheck: true,
+  });
+  const log = `time="2026-09-02T07:15:48+02:00" level=info msg=${JSON.stringify(event)} source=console`;
+  const result = buildEvidence(log, { metrics: {} }, "scale");
+  assert.equal(result.completedAt, "2026-09-02T05:15:48.861Z");
+  assert.equal(result.replicaCount, 2);
+});

--- a/scripts/load/load-test.js
+++ b/scripts/load/load-test.js
@@ -1,0 +1,156 @@
+import http from "k6/http";
+import { check, fail } from "k6";
+import exec from "k6/execution";
+import { createLoadOptions, requiresMultipleReplicas } from "./config.mjs";
+
+const profile = __ENV.LOAD_PROFILE || "baseline";
+const baseUrl = (__ENV.PUBLIC_BASE_URL || "").replace(/\/$/, "");
+const loadToken = __ENV.LOAD_TEST_TOKEN || "";
+
+export const options = createLoadOptions(profile);
+
+function headers(id) {
+  return {
+    "Content-Type": "application/json",
+    "Idempotency-Key": id,
+    "X-Request-Id": id,
+    "X-Load-Test-Token": loadToken,
+  };
+}
+
+function safeJson(response) {
+  try {
+    return response.json();
+  } catch {
+    return {};
+  }
+}
+
+function instanceId(response) {
+  return response.headers["X-Instance-Id"] || response.headers["x-instance-id"] || "unknown";
+}
+
+export function setup() {
+  const localTarget = /^http:\/\/(127\.0\.0\.1|localhost|host\.docker\.internal)(:\d+)?$/.test(
+    baseUrl,
+  );
+  if (!baseUrl || (!baseUrl.startsWith("https://") && !localTarget)) {
+    fail("PUBLIC_BASE_URL HTTPS est requis hors localhost");
+  }
+  if (loadToken.length < 32)
+    fail("LOAD_TEST_TOKEN est requis et doit contenir au moins 32 caractères");
+
+  const ready = http.get(`${baseUrl}/ready`, { tags: { operation: "ready" } });
+  const rules = http.get(`${baseUrl}/api/rules`, { tags: { operation: "rules" } });
+  check(ready, {
+    "readiness normal avant charge": (response) =>
+      response.status === 200 && safeJson(response).mode === "normal",
+  });
+  check(rules, {
+    "contrat EUR et cinq règles": (response) => {
+      const body = safeJson(response);
+      return response.status === 200 && body.currency === "EUR" && body.rules?.length === 5;
+    },
+  });
+  return { startedAt: new Date().toISOString() };
+}
+
+export function evaluateDecision() {
+  const suffix = `${profile}-${exec.vu.idInTest}-${exec.scenario.iterationInTest}`;
+  const transaction = {
+    transactionId: `load-${suffix}`,
+    cardId: `load-card-${suffix}`,
+    amount: 20,
+    currency: "EUR",
+    country: "FR",
+    channel: "in_store",
+    merchantCategory: "grocery",
+  };
+  const response = http.post(`${baseUrl}/api/decisions`, JSON.stringify(transaction), {
+    headers: headers(`load-${suffix}`),
+    tags: { operation: "decision", profile },
+  });
+  const body = safeJson(response);
+  check(response, {
+    "décision HTTP 200": (value) => value.status === 200,
+    "décision non dégradée": () => body.degraded === false,
+    "décision expliquée": () =>
+      ["APPROVED", "REVIEW", "REJECTED"].includes(body.decision) && Number.isInteger(body.score),
+    "instance identifiable": (value) => instanceId(value) !== "unknown",
+  });
+}
+
+export function teardown(data) {
+  const replicaRequests = Array.from({ length: 100 }, (_, index) => ({
+    method: "GET",
+    url: `${baseUrl}/ready`,
+    params: {
+      headers: { "X-Request-Id": `replica-${Date.now()}-${index}` },
+      tags: { operation: "replica_probe" },
+    },
+  }));
+  const replicaResponses = http.batch(replicaRequests);
+  const replicas = [...new Set(replicaResponses.map(instanceId).filter((id) => id !== "unknown"))];
+
+  const velocityId = `${Date.now()}-${Math.floor(Math.random() * 1_000_000)}`;
+  const velocityRequests = Array.from({ length: 8 }, (_, index) => {
+    const id = `velocity-${velocityId}-${index}`;
+    return {
+      method: "POST",
+      url: `${baseUrl}/api/decisions`,
+      body: JSON.stringify({
+        transactionId: id,
+        cardId: `shared-card-${velocityId}`,
+        amount: 20,
+        currency: "EUR",
+        country: "FR",
+        channel: "in_store",
+        merchantCategory: "grocery",
+      }),
+      params: { headers: headers(id), tags: { operation: "velocity_probe" } },
+    };
+  });
+  const velocityResponses = http.batch(velocityRequests);
+  const velocityDecisions = velocityResponses.map(safeJson);
+  const velocityTriggered = velocityDecisions.filter((decision) =>
+    decision.reasons?.some((reason) => reason.rule === "VELOCITY"),
+  ).length;
+  const velocityReplicas = [
+    ...new Set(velocityResponses.map(instanceId).filter((id) => id !== "unknown")),
+  ];
+
+  const replicaCheck = check(replicas, {
+    "au moins un replica observé": (values) => values.length >= 1,
+    "plusieurs replicas sous montée en charge": (values) =>
+      !requiresMultipleReplicas(profile) || values.length >= 2,
+  });
+  const velocityCheck = check(velocityDecisions, {
+    "vélocité Redis cohérente": (values) =>
+      values.length === 8 &&
+      values.every((value) => value.degraded === false) &&
+      velocityTriggered >= 5,
+  });
+
+  console.log(
+    JSON.stringify({
+      event: "load_evidence",
+      profile,
+      startedAt: data.startedAt,
+      completedAt: new Date().toISOString(),
+      replicas,
+      replicaCount: replicas.length,
+      velocityReplicas,
+      velocityTriggered,
+      replicaCheck,
+      velocityCheck,
+    }),
+  );
+}
+
+export function handleSummary(data) {
+  const target = __ENV.K6_SUMMARY_PATH || "artifacts/k6-summary.json";
+  return {
+    [target]: JSON.stringify(data, null, 2),
+    stdout: `\nRésumé k6 ${profile}: ${data.state?.testRunDurationMs ?? 0} ms\n`,
+  };
+}

--- a/scripts/release/manifest.mjs
+++ b/scripts/release/manifest.mjs
@@ -1,0 +1,62 @@
+import fs from "node:fs";
+import process from "node:process";
+import { pathToFileURL } from "node:url";
+
+const EXACT_KEYS = ["version", "sourceSha", "apiImage", "webImage", "createdAt"];
+const IMAGE_PATTERN =
+  /^[a-z0-9][a-z0-9.-]*\.azurecr\.io\/[a-z0-9][a-z0-9._/-]*@sha256:[a-f0-9]{64}$/;
+
+function invariant(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+export function validateReleaseManifest(manifest, expectedRegistry) {
+  invariant(
+    manifest && typeof manifest === "object" && !Array.isArray(manifest),
+    "manifest JSON invalide",
+  );
+  invariant(
+    Object.keys(manifest).sort().join(",") === [...EXACT_KEYS].sort().join(","),
+    "champs du manifeste inattendus ou manquants",
+  );
+  invariant(
+    /^v\d+\.\d+\.\d+$/.test(manifest.version),
+    "version SemVer vMAJOR.MINOR.PATCH invalide",
+  );
+  invariant(/^[a-f0-9]{40}$/.test(manifest.sourceSha), "sourceSha Git complet invalide");
+  invariant(
+    IMAGE_PATTERN.test(manifest.apiImage),
+    "apiImage doit être une référence ACR par digest",
+  );
+  invariant(
+    IMAGE_PATTERN.test(manifest.webImage),
+    "webImage doit être une référence ACR par digest",
+  );
+  invariant(!Number.isNaN(Date.parse(manifest.createdAt)), "createdAt ISO-8601 invalide");
+
+  if (expectedRegistry) {
+    const prefix = `${expectedRegistry}.azurecr.io/`;
+    invariant(manifest.apiImage.startsWith(prefix), "apiImage ne vient pas du registre attendu");
+    invariant(manifest.webImage.startsWith(prefix), "webImage ne vient pas du registre attendu");
+  }
+  return Object.freeze({ ...manifest });
+}
+
+export function readReleaseManifest(file, expectedRegistry) {
+  return validateReleaseManifest(JSON.parse(fs.readFileSync(file, "utf8")), expectedRegistry);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const file = process.argv[2] ?? ".release/manifest.json";
+  const manifest = readReleaseManifest(file, process.env.AZURE_CONTAINER_REGISTRY);
+  const output = [
+    `version=${manifest.version}`,
+    `source_sha=${manifest.sourceSha}`,
+    `api_image=${manifest.apiImage}`,
+    `web_image=${manifest.webImage}`,
+  ].join("\n");
+  if (process.env.GITHUB_OUTPUT) {
+    fs.appendFileSync(process.env.GITHUB_OUTPUT, `${output}\n`, { encoding: "utf8", mode: 0o600 });
+  }
+  console.log(JSON.stringify({ event: "release_manifest_validated", ...manifest }));
+}

--- a/scripts/release/manifest.test.mjs
+++ b/scripts/release/manifest.test.mjs
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { validateReleaseManifest } from "./manifest.mjs";
+
+const valid = {
+  version: "v1.0.0",
+  sourceSha: "a".repeat(40),
+  apiImage: `registry.azurecr.io/transaction-risk-gate-api@sha256:${"b".repeat(64)}`,
+  webImage: `registry.azurecr.io/transaction-risk-gate-web@sha256:${"c".repeat(64)}`,
+  createdAt: "2026-09-01T00:00:00.000Z",
+};
+
+test("accepte uniquement deux images ACR immuables du registre attendu", () => {
+  assert.deepEqual(validateReleaseManifest(valid, "registry"), valid);
+});
+
+test("refuse tags mutables, mauvais registre et champs supplémentaires", () => {
+  assert.throws(
+    () =>
+      validateReleaseManifest({
+        ...valid,
+        apiImage: "registry.azurecr.io/transaction-risk-gate-api:latest",
+      }),
+    /digest/,
+  );
+  assert.throws(() => validateReleaseManifest(valid, "other"), /registre attendu/);
+  assert.throws(() => validateReleaseManifest({ ...valid, token: "interdit" }), /champs/);
+});

--- a/scripts/smoke/smoke-test.mjs
+++ b/scripts/smoke/smoke-test.mjs
@@ -1,0 +1,118 @@
+import process from "node:process";
+import { randomUUID } from "node:crypto";
+import { pathToFileURL } from "node:url";
+
+const DEFAULT_TIMEOUT_MS = 180_000;
+const DEFAULT_INTERVAL_MS = 5_000;
+
+function invariant(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function normalizeBaseUrl(value) {
+  const url = new URL(value);
+  invariant(
+    url.protocol === "https:" || url.hostname === "127.0.0.1",
+    "HTTPS est obligatoire hors localhost",
+  );
+  return url.toString().replace(/\/$/, "");
+}
+
+async function requestJson(fetchImpl, url, options = {}) {
+  const response = await fetchImpl(url, {
+    ...options,
+    signal: AbortSignal.timeout(10_000),
+  });
+  invariant(response.ok, `${options.method ?? "GET"} ${url} a répondu HTTP ${response.status}`);
+  return { response, body: await response.json() };
+}
+
+export async function runSmokeOnce(fetchImpl, rawBaseUrl, id = randomUUID()) {
+  const baseUrl = normalizeBaseUrl(rawBaseUrl);
+
+  const health = await fetchImpl(`${baseUrl}/healthz`, { signal: AbortSignal.timeout(10_000) });
+  invariant(health.ok, `/healthz a répondu HTTP ${health.status}`);
+  invariant((await health.text()).trim() === "ok", "/healthz ne renvoie pas ok");
+
+  const { body: ready } = await requestJson(fetchImpl, `${baseUrl}/ready`);
+  invariant(ready.status === "ready", "/ready ne signale pas ready");
+  invariant(ready.mode === "normal", "/ready signale un mode dégradé");
+  invariant(ready.dependencies?.redis === "available", "/ready ne confirme pas Redis");
+
+  const { body: rules } = await requestJson(fetchImpl, `${baseUrl}/api/rules`);
+  invariant(rules.currency === "EUR", "le contrat métier ne signale pas EUR");
+  invariant(
+    Array.isArray(rules.rules) && rules.rules.length === 5,
+    "les cinq règles ne sont pas actives",
+  );
+  invariant(
+    rules.rules.reduce((sum, rule) => sum + rule.weight, 0) === 100,
+    "les poids ne totalisent pas 100",
+  );
+
+  const transaction = {
+    transactionId: `smoke_${id}`,
+    cardId: `smoke_card_${id}`,
+    amount: 20,
+    currency: "EUR",
+    country: "FR",
+    channel: "in_store",
+    merchantCategory: "grocery",
+  };
+  const headers = {
+    "Content-Type": "application/json",
+    "Idempotency-Key": `smoke-${id}`,
+    "X-Request-Id": `smoke.${id}`,
+  };
+  const options = { method: "POST", headers, body: JSON.stringify(transaction) };
+  const first = await requestJson(fetchImpl, `${baseUrl}/api/decisions`, options);
+  invariant(
+    first.body.decision === "APPROVED",
+    "la transaction synthétique saine n'est pas APPROVED",
+  );
+  invariant(first.body.degraded === false, "la décision synthétique est dégradée");
+  invariant(first.response.headers.get("x-instance-id"), "X-Instance-Id est absent");
+
+  const replay = await requestJson(fetchImpl, `${baseUrl}/api/decisions`, options);
+  invariant(
+    replay.body.decisionId === first.body.decisionId,
+    "le rejeu idempotent diffère de la première réponse",
+  );
+
+  return Object.freeze({
+    baseUrl,
+    mode: ready.mode,
+    redis: ready.dependencies.redis,
+    rules: rules.rules.length,
+    decision: first.body.decision,
+    decisionId: first.body.decisionId,
+    instanceId: first.response.headers.get("x-instance-id"),
+    replayed: true,
+  });
+}
+
+export async function runSmokeWithRetry(
+  fetchImpl,
+  baseUrl,
+  { timeoutMs = DEFAULT_TIMEOUT_MS, intervalMs = DEFAULT_INTERVAL_MS } = {},
+) {
+  const deadline = Date.now() + timeoutMs;
+  let lastError;
+  do {
+    try {
+      return await runSmokeOnce(fetchImpl, baseUrl);
+    } catch (error) {
+      lastError = error;
+      if (Date.now() + intervalMs > deadline) break;
+      await new Promise((resolve) => setTimeout(resolve, intervalMs));
+    }
+  } while (Date.now() < deadline);
+  throw new Error(`Smoke test impossible après ${timeoutMs} ms`, { cause: lastError });
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const baseUrl = process.env.PUBLIC_BASE_URL ?? process.argv[2];
+  invariant(baseUrl, "PUBLIC_BASE_URL ou un premier argument est requis");
+  const summary = await runSmokeWithRetry(fetch, baseUrl);
+  console.log(JSON.stringify({ event: "smoke_passed", ...summary }));
+}

--- a/scripts/smoke/smoke-test.test.mjs
+++ b/scripts/smoke/smoke-test.test.mjs
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { runSmokeOnce } from "./smoke-test.mjs";
+
+function json(body, headers = {}) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json", ...headers },
+  });
+}
+
+test("valide santé, Redis, règles, décision et rejeu sans secret", async () => {
+  const requests = [];
+  const fetchImpl = async (url, options = {}) => {
+    requests.push({ url, options });
+    if (url.endsWith("/healthz")) return new Response("ok\n");
+    if (url.endsWith("/ready")) {
+      return json({ status: "ready", mode: "normal", dependencies: { redis: "available" } });
+    }
+    if (url.endsWith("/api/rules")) {
+      return json({
+        currency: "EUR",
+        rules: [30, 25, 20, 15, 10].map((weight) => ({ weight })),
+      });
+    }
+    return json(
+      { decisionId: "dec-smoke", decision: "APPROVED", degraded: false },
+      { "X-Instance-Id": "api-1" },
+    );
+  };
+
+  const summary = await runSmokeOnce(fetchImpl, "https://example.test/", "fixed-id");
+
+  assert.equal(summary.replayed, true);
+  assert.equal(summary.instanceId, "api-1");
+  assert.equal(requests.filter(({ url }) => url.endsWith("/api/decisions")).length, 2);
+  assert.equal(
+    requests.some(({ options }) => options.headers?.["X-API-Key"]),
+    false,
+  );
+});
+
+test("refuse un readiness dégradé", async () => {
+  const fetchImpl = async (url) => {
+    if (url.endsWith("/healthz")) return new Response("ok\n");
+    return json({ status: "ready", mode: "degraded", dependencies: { redis: "unavailable" } });
+  };
+
+  await assert.rejects(
+    () => runSmokeOnce(fetchImpl, "https://example.test", "fixed-id"),
+    /dégradé/,
+  );
+});

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,14 @@
+sonar.projectName=Transaction Risk Gate
+sonar.sourceEncoding=UTF-8
+
+sonar.sources=api/src,web
+sonar.tests=api/src,web
+sonar.exclusions=api/src/**/*.test.ts,api/src/test-helpers.ts,web/*.test.mjs,web/node_modules/**,web/coverage/**,api/dist/**,api/node_modules/**,api/coverage/**
+sonar.test.inclusions=api/src/**/*.test.ts,api/src/test-helpers.ts,web/*.test.mjs
+
+sonar.javascript.lcov.reportPaths=api/coverage/lcov.info,web/coverage/lcov.info
+sonar.typescript.tsconfigPaths=api/tsconfig.json
+
+# Contrat TypeScript pur, composition root et serveur de développement local :
+# ces fichiers n’hébergent pas de logique métier et sont vérifiés autrement.
+sonar.coverage.exclusions=api/src/decision.ts,api/src/server.ts,web/dev-server.mjs


### PR DESCRIPTION
## Résultat attendu

Établir le cadre d'ingénierie qui gouverne tout changement ultérieur : politique Git exécutable,
Definition of Done, quality gates, politique de release, hooks locaux, CI de gouvernance et socle
documentaire complet (architecture, métier, décisions, sécurité, exploitation, livraison, limites).

## Travail et périmètre

- Issue : `TRG-1` / #10
- Branche source : `chore/TRG-1-installer-la-gouvernance` → `develop`
- Labels : `type:chore`, `risk:low`, `area:quality`, `area:docs`, `release:not-required`
- Inclus : configuration de format/lint/scan, `scripts/governance/` + tests, `.githooks/` +
  `pre-commit`, outillage opérationnel (`scripts/{smoke,release,load,failure}/`), toute la
  documentation `docs/`, la CI `Gouvernance`, `dependabot.yml`, `labeler.yml`, le gabarit de PR.
- Explicitement exclu : `api/`, `web/`, `infra/`, `docker-compose.yml` — livrés avec leurs tranches.

## Risques et compatibilité

- Niveau de risque : low — aucun code exécutable en production, aucun secret.
- Impact API / infra : nul.
- Rollback : `develop` reste fonctionnel sans cette PR.

## Vérification

- `node --test scripts/governance/tests/git-policy.test.mjs` : 10/10.
- `node scripts/governance/validate-repository.mjs` : OK (26 fichiers Markdown, 3 ADR, liens résolus).
- `prettier --check` et `markdownlint-cli2` : clean.
- `pre-commit run --all-files` : tous les hooks `Passed` (gitleaks, format, markdown,
  repository-policy, governance-tests, operations-tests).

## Notes pour le reviewer

La CI démarre volontairement avec le seul job `Gouvernance`. Les jobs `Tests existants`,
`SonarCloud`, `Snyk`, `Infrastructure` et `Images et Trivy` sont ajoutés par les tranches qui
apportent le code qu'ils contrôlent (TRG-2, TRG-6, TRG-7, TRG-8), avec les checks requis
correspondants.

Closes #10
