### PR TITLE
[TRG-3] garantir vélocité et idempotence avec Redis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,15 @@ jobs:
       - governance
     runs-on: ubuntu-24.04
     timeout-minutes: 20
+    services:
+      redis:
+        image: redis:8.10.1-alpine3.23@sha256:becdda6c7f4b3fb42e42fd7f120bbf5c54c4caaaf16f26da24e4563d2c1f0576
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping" --health-interval 5s --health-timeout 3s --health-retries 10
+    env:
+      REDIS_TEST_URL: redis://127.0.0.1:6379
     steps:
       - name: Récupérer le dépôt
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/api/src/application/evaluate-transaction.test.ts
+++ b/api/src/application/evaluate-transaction.test.ts
@@ -1,0 +1,51 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type { RiskPolicy, Transaction } from "../domain/risk-engine.js";
+import type { VelocityStore } from "../velocity-store.js";
+import { evaluateTransaction } from "./evaluate-transaction.js";
+
+const policy: RiskPolicy = {
+  amountThreshold: 1000,
+  velocityMax: 3,
+  velocityWindowSeconds: 60,
+  allowedCountries: ["FR"],
+  highRiskMerchantCategories: ["crypto"],
+};
+
+const transaction: Transaction = {
+  transactionId: "txn_1",
+  cardId: "card_1",
+  amount: 20,
+  currency: "EUR",
+  country: "FR",
+  channel: "in_store",
+  merchantCategory: "grocery",
+};
+
+test("records velocity once and delegates the returned context to the domain", async () => {
+  const observedCardIds: string[] = [];
+  const store: VelocityStore = {
+    hit: async (cardId) => {
+      observedCardIds.push(cardId);
+      return 4;
+    },
+  };
+
+  const result = await evaluateTransaction(transaction, policy, store);
+
+  assert.deepEqual(observedCardIds, ["card_1"]);
+  assert.equal(result.score, 30);
+  assert.equal(result.decision, "REVIEW");
+  assert.equal(result.reasons[0]?.rule, "VELOCITY");
+});
+
+test("propagates a velocity dependency failure without fabricating a decision", async () => {
+  const store: VelocityStore = {
+    hit: () => Promise.reject(new Error("velocity unavailable")),
+  };
+
+  await assert.rejects(
+    () => evaluateTransaction(transaction, policy, store),
+    /velocity unavailable/,
+  );
+});

--- a/api/src/application/evaluate-transaction.ts
+++ b/api/src/application/evaluate-transaction.ts
@@ -1,0 +1,20 @@
+import type { VelocityStore } from "../velocity-store.js";
+import {
+  evaluateRisk,
+  type Evaluation,
+  type RiskPolicy,
+  type Transaction,
+} from "../domain/risk-engine.js";
+
+/**
+ * Cas d'usage applicatif : enrichir la transaction avec son contexte de
+ * vélocité, puis déléguer toute décision au moteur de domaine pur.
+ */
+export async function evaluateTransaction(
+  transaction: Transaction,
+  policy: RiskPolicy,
+  velocityStore: VelocityStore,
+): Promise<Evaluation> {
+  const velocityCount = await velocityStore.hit(transaction.cardId);
+  return evaluateRisk(transaction, policy, { velocityCount });
+}

--- a/api/src/idempotency-store.test.ts
+++ b/api/src/idempotency-store.test.ts
@@ -1,0 +1,78 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type { DecisionResponse } from "./decision.js";
+import { InMemoryIdempotencyStore } from "./idempotency-store.js";
+import { IdempotencyConflictError } from "./infrastructure/state-store-errors.js";
+
+const decision = (decisionId: string): DecisionResponse => ({
+  decisionId,
+  decision: "APPROVED",
+  score: 0,
+  reasons: [],
+  evaluatedAt: "2026-09-01T00:00:00.000Z",
+  degraded: false,
+});
+
+test("replays one operation for concurrent identical requests", async () => {
+  const store = new InMemoryIdempotencyStore();
+  let evaluations = 0;
+  const operation = async () => {
+    evaluations += 1;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    return decision("dec_single");
+  };
+
+  const results = await Promise.all(
+    Array.from({ length: 10 }, () => store.execute("key", "hash-a", operation)),
+  );
+
+  assert.equal(evaluations, 1);
+  assert.deepEqual(
+    new Set(results.map((result) => result.decision.decisionId)),
+    new Set(["dec_single"]),
+  );
+  assert.equal(results.filter((result) => result.replayed).length, 9);
+});
+
+test("rejects a payload mismatch while the first operation is pending", async () => {
+  const store = new InMemoryIdempotencyStore();
+  let release: ((value: DecisionResponse) => void) | undefined;
+  const pending = new Promise<DecisionResponse>((resolve) => {
+    release = resolve;
+  });
+
+  const first = store.execute("key", "hash-a", () => pending);
+  await assert.rejects(
+    () => store.execute("key", "hash-b", () => Promise.resolve(decision("dec_other"))),
+    IdempotencyConflictError,
+  );
+  release?.(decision("dec_first"));
+  await first;
+});
+
+test("evaluates again after the configured TTL", async () => {
+  let now = 0;
+  const store = new InMemoryIdempotencyStore(1, () => now);
+  let evaluations = 0;
+  const operation = async () => decision(`dec_${++evaluations}`);
+
+  await store.execute("key", "hash", operation);
+  now = 1_000;
+  const result = await store.execute("key", "hash", operation);
+
+  assert.equal(evaluations, 2);
+  assert.equal(result.decision.decisionId, "dec_2");
+  assert.equal(result.replayed, false);
+});
+
+test("releases a failed operation so a retry can evaluate", async () => {
+  const store = new InMemoryIdempotencyStore();
+  await assert.rejects(
+    () => store.execute("key", "hash", () => Promise.reject(new Error("failed"))),
+    /failed/,
+  );
+
+  const result = await store.execute("key", "hash", () => Promise.resolve(decision("dec_retry")));
+  assert.equal(result.decision.decisionId, "dec_retry");
+  assert.equal(result.replayed, false);
+});

--- a/api/src/idempotency-store.ts
+++ b/api/src/idempotency-store.ts
@@ -1,0 +1,61 @@
+import type { DecisionResponse } from "./decision.js";
+import { IdempotencyConflictError } from "./infrastructure/state-store-errors.js";
+
+export type IdempotentResult = Readonly<{
+  decision: DecisionResponse;
+  replayed: boolean;
+}>;
+
+export interface IdempotencyStore {
+  execute(
+    key: string,
+    payloadHash: string,
+    operation: () => Promise<DecisionResponse>,
+  ): Promise<IdempotentResult>;
+}
+
+type MemoryEntry = {
+  payloadHash: string;
+  expiresAt: number;
+  decision: Promise<DecisionResponse>;
+};
+
+/** Implémentation single-flight utilisée par les tests sans Redis. */
+export class InMemoryIdempotencyStore implements IdempotencyStore {
+  readonly #entries = new Map<string, MemoryEntry>();
+  readonly #ttlMs: number;
+  readonly #now: () => number;
+
+  constructor(ttlSeconds = 86_400, now: () => number = () => Date.now()) {
+    this.#ttlMs = ttlSeconds * 1_000;
+    this.#now = now;
+  }
+
+  async execute(
+    key: string,
+    payloadHash: string,
+    operation: () => Promise<DecisionResponse>,
+  ): Promise<IdempotentResult> {
+    const existing = this.#entries.get(key);
+    if (existing !== undefined && existing.expiresAt > this.#now()) {
+      if (existing.payloadHash !== payloadHash) throw new IdempotencyConflictError();
+      return { decision: await existing.decision, replayed: true };
+    }
+    if (existing !== undefined) this.#entries.delete(key);
+
+    const decision = Promise.resolve().then(operation);
+    const entry: MemoryEntry = {
+      payloadHash,
+      expiresAt: this.#now() + this.#ttlMs,
+      decision,
+    };
+    this.#entries.set(key, entry);
+
+    try {
+      return { decision: await decision, replayed: false };
+    } catch (error) {
+      if (this.#entries.get(key) === entry) this.#entries.delete(key);
+      throw error;
+    }
+  }
+}

--- a/api/src/infrastructure/circuit-breaker.test.ts
+++ b/api/src/infrastructure/circuit-breaker.test.ts
@@ -1,0 +1,69 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { CircuitBreaker, type CircuitState } from "./circuit-breaker.js";
+import { StateStoreUnavailableError } from "./state-store-errors.js";
+
+test("opens after the configured failures and rejects calls while open", async () => {
+  let calls = 0;
+  const breaker = new CircuitBreaker({ failureThreshold: 2, resetAfterMs: 100, timeoutMs: 50 });
+  const failingOperation = async () => {
+    calls += 1;
+    throw new Error("redis down");
+  };
+
+  await assert.rejects(() => breaker.execute(failingOperation), StateStoreUnavailableError);
+  assert.equal(breaker.state, "CLOSED");
+  await assert.rejects(() => breaker.execute(failingOperation), StateStoreUnavailableError);
+  assert.equal(breaker.state, "OPEN");
+  await assert.rejects(() => breaker.execute(failingOperation), /circuit is open/);
+  assert.equal(calls, 2);
+});
+
+test("allows one half-open probe and closes after recovery", async () => {
+  let now = 0;
+  const transitions: Array<[CircuitState, CircuitState]> = [];
+  const breaker = new CircuitBreaker({
+    failureThreshold: 1,
+    resetAfterMs: 100,
+    timeoutMs: 50,
+    now: () => now,
+    onTransition: (from, to) => transitions.push([from, to]),
+  });
+
+  await assert.rejects(
+    () => breaker.execute(() => Promise.reject(new Error("down"))),
+    StateStoreUnavailableError,
+  );
+  now = 100;
+  assert.equal(await breaker.execute(() => Promise.resolve("recovered")), "recovered");
+  assert.equal(breaker.state, "CLOSED");
+  assert.deepEqual(transitions, [
+    ["CLOSED", "OPEN"],
+    ["OPEN", "HALF_OPEN"],
+    ["HALF_OPEN", "CLOSED"],
+  ]);
+});
+
+test("a failed half-open probe reopens the circuit", async () => {
+  let now = 0;
+  const breaker = new CircuitBreaker({
+    failureThreshold: 1,
+    resetAfterMs: 100,
+    timeoutMs: 50,
+    now: () => now,
+  });
+
+  await assert.rejects(() => breaker.execute(() => Promise.reject(new Error("down"))));
+  now = 100;
+  await assert.rejects(() => breaker.execute(() => Promise.reject(new Error("still down"))));
+  assert.equal(breaker.state, "OPEN");
+});
+
+test("times out a slow operation", async () => {
+  const breaker = new CircuitBreaker({ failureThreshold: 1, resetAfterMs: 100, timeoutMs: 5 });
+  await assert.rejects(
+    () => breaker.execute(() => new Promise((resolve) => setTimeout(resolve, 100))),
+    /timed out/,
+  );
+  assert.equal(breaker.state, "OPEN");
+});

--- a/api/src/infrastructure/circuit-breaker.ts
+++ b/api/src/infrastructure/circuit-breaker.ts
@@ -1,0 +1,98 @@
+import { StateStoreUnavailableError } from "./state-store-errors.js";
+
+export type CircuitState = "CLOSED" | "OPEN" | "HALF_OPEN";
+
+export type CircuitBreakerOptions = Readonly<{
+  failureThreshold: number;
+  resetAfterMs: number;
+  timeoutMs: number;
+  now?: () => number;
+  onTransition?: (from: CircuitState, to: CircuitState) => void;
+}>;
+
+export class CircuitBreaker {
+  readonly #options: CircuitBreakerOptions;
+  readonly #now: () => number;
+  #state: CircuitState = "CLOSED";
+  #consecutiveFailures = 0;
+  #openedAt = 0;
+
+  constructor(options: CircuitBreakerOptions) {
+    this.#options = options;
+    this.#now = options.now ?? (() => Date.now());
+  }
+
+  get state(): CircuitState {
+    return this.#state;
+  }
+
+  async execute<T>(operation: () => Promise<T>): Promise<T> {
+    this.#admitOperation();
+
+    try {
+      const result = await this.#withTimeout(operation);
+      this.#recordSuccess();
+      return result;
+    } catch (cause) {
+      this.#recordFailure();
+      if (cause instanceof StateStoreUnavailableError) throw cause;
+      throw new StateStoreUnavailableError("shared state operation failed", cause);
+    }
+  }
+
+  #admitOperation(): void {
+    if (this.#state === "CLOSED") return;
+
+    if (this.#state === "OPEN") {
+      if (this.#now() - this.#openedAt < this.#options.resetAfterMs) {
+        throw new StateStoreUnavailableError("shared state circuit is open");
+      }
+      this.#transitionTo("HALF_OPEN");
+      return;
+    }
+
+    throw new StateStoreUnavailableError("shared state circuit half-open probe is in progress");
+  }
+
+  async #withTimeout<T>(operation: () => Promise<T>): Promise<T> {
+    let timeout: NodeJS.Timeout | undefined;
+    const expired = new Promise<never>((_resolve, reject) => {
+      timeout = setTimeout(
+        () => reject(new StateStoreUnavailableError("shared state command timed out")),
+        this.#options.timeoutMs,
+      );
+    });
+
+    try {
+      return await Promise.race([operation(), expired]);
+    } finally {
+      if (timeout !== undefined) clearTimeout(timeout);
+    }
+  }
+
+  #recordSuccess(): void {
+    this.#consecutiveFailures = 0;
+    if (this.#state !== "CLOSED") this.#transitionTo("CLOSED");
+  }
+
+  #recordFailure(): void {
+    if (this.#state === "HALF_OPEN") {
+      this.#openedAt = this.#now();
+      this.#transitionTo("OPEN");
+      return;
+    }
+
+    this.#consecutiveFailures += 1;
+    if (this.#consecutiveFailures >= this.#options.failureThreshold) {
+      this.#openedAt = this.#now();
+      this.#transitionTo("OPEN");
+    }
+  }
+
+  #transitionTo(next: CircuitState): void {
+    if (this.#state === next) return;
+    const previous = this.#state;
+    this.#state = next;
+    this.#options.onTransition?.(previous, next);
+  }
+}

--- a/api/src/infrastructure/redis-state-store.integration.test.ts
+++ b/api/src/infrastructure/redis-state-store.integration.test.ts
@@ -1,0 +1,155 @@
+import { test, type TestContext } from "node:test";
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { createClient } from "redis";
+import type { DecisionResponse } from "../decision.js";
+import { IdempotencyConflictError } from "./state-store-errors.js";
+import { RedisStateStore, type RedisStateStoreOptions } from "./redis-state-store.js";
+
+const redisUrl = process.env.REDIS_TEST_URL;
+const skip = redisUrl === undefined ? "REDIS_TEST_URL absent" : false;
+const hmacSecret = "integration-hmac-secret-at-least-32-bytes";
+
+const decision = (decisionId: string): DecisionResponse => ({
+  decisionId,
+  decision: "APPROVED",
+  score: 0,
+  reasons: [],
+  evaluatedAt: "2026-09-01T00:00:00.000Z",
+  degraded: false,
+});
+
+const createStore = (namespace: string, overrides: Partial<RedisStateStoreOptions> = {}) =>
+  new RedisStateStore({
+    url: redisUrl ?? "redis://127.0.0.1:6379",
+    hmacSecret,
+    velocityWindowSeconds: 60,
+    commandTimeoutMs: 250,
+    circuitFailureThreshold: 3,
+    circuitResetMs: 100,
+    idempotencyTtlSeconds: 86_400,
+    idempotencyLockMs: 5_000,
+    idempotencyWaitMs: 2_000,
+    namespace,
+    ...overrides,
+  });
+
+const withAdmin = async (t: TestContext) => {
+  const admin = createClient({ url: redisUrl });
+  admin.on("error", () => {});
+  await admin.connect();
+  t.after(() => admin.destroy());
+  return admin;
+};
+
+test("Redis startup probe resolves the initial availability", { skip }, async (t) => {
+  const transitions: string[] = [];
+  const store = createStore(`trg-test-${randomUUID()}`, {
+    onAvailabilityChange: (from, to) => transitions.push(`${from}->${to}`),
+  });
+  t.after(() => store.close());
+
+  assert.equal(store.availability, "unknown");
+  await store.probe();
+  assert.equal(store.availability, "available");
+  assert.deepEqual(transitions, ["unknown->available"]);
+});
+
+test(
+  "Redis shares atomic velocity across replicas and hides card identifiers",
+  { skip },
+  async (t) => {
+    const namespace = `trg-test-${randomUUID()}`;
+    const first = createStore(namespace);
+    const second = createStore(namespace);
+    t.after(() => first.close());
+    t.after(() => second.close());
+    const admin = await withAdmin(t);
+
+    assert.equal(await first.hit("card-sensitive-42"), 1);
+    assert.equal(await second.hit("card-sensitive-42"), 2);
+    assert.equal(await first.hit("card-sensitive-42"), 3);
+
+    const keys = await admin.keys(`${namespace}:*`);
+    assert.equal(keys.length, 1);
+    assert.doesNotMatch(keys[0] ?? "", /card-sensitive-42/);
+    const ttl = await admin.ttl(keys[0] ?? "");
+    assert.ok(ttl > 0 && ttl <= 60, `TTL inattendu : ${ttl}`);
+  },
+);
+
+test("Redis velocity expires at the configured fixed-window TTL", { skip }, async (t) => {
+  const namespace = `trg-test-${randomUUID()}`;
+  const store = createStore(namespace, { velocityWindowSeconds: 1 });
+  t.after(() => store.close());
+
+  assert.equal(await store.hit("card-expiring"), 1);
+  assert.equal(await store.hit("card-expiring"), 2);
+  await new Promise((resolve) => setTimeout(resolve, 1_100));
+  assert.equal(await store.hit("card-expiring"), 1);
+});
+
+test("Redis shares and pseudonymizes the rate limit counter", { skip }, async (t) => {
+  const namespace = `trg-test-${randomUUID()}`;
+  const first = createStore(namespace);
+  const second = createStore(namespace);
+  t.after(() => first.close());
+  t.after(() => second.close());
+  const admin = await withAdmin(t);
+
+  const initial = await first.incrementRateLimit("public:203.0.113.10", 60_000);
+  assert.equal(initial.current, 1);
+  assert.ok(initial.ttl > 0 && initial.ttl <= 60_000);
+  const next = await second.incrementRateLimit("public:203.0.113.10", 60_000);
+  assert.equal(next.current, 2);
+  assert.ok(next.ttl > 0 && next.ttl <= 60_000);
+
+  const keys = await admin.keys(`${namespace}:rate-limit:*`);
+  assert.equal(keys.length, 1);
+  assert.doesNotMatch(keys[0] ?? "", /203\.0\.113\.10/);
+});
+
+test(
+  "Redis idempotency is single-flight, replayed for 24h and pseudonymized",
+  { skip },
+  async (t) => {
+    const namespace = `trg-test-${randomUUID()}`;
+    const first = createStore(namespace);
+    const second = createStore(namespace);
+    t.after(() => first.close());
+    t.after(() => second.close());
+    const admin = await withAdmin(t);
+    let evaluations = 0;
+
+    const operation = async () => {
+      evaluations += 1;
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      return decision("dec_distributed");
+    };
+    const results = await Promise.all(
+      Array.from({ length: 10 }, (_unused, index) =>
+        (index % 2 === 0 ? first : second).execute(
+          "idem-sensitive-key",
+          "payload-hash-a",
+          operation,
+        ),
+      ),
+    );
+
+    assert.equal(evaluations, 1);
+    assert.equal(new Set(results.map((result) => result.decision.decisionId)).size, 1);
+    assert.equal(results.filter((result) => result.replayed).length, 9);
+
+    const keys = await admin.keys(`${namespace}:*`);
+    assert.equal(keys.length, 1);
+    assert.doesNotMatch(keys[0] ?? "", /idem-sensitive-key/);
+    const ttl = await admin.ttl(keys[0] ?? "");
+    assert.ok(ttl > 86_300 && ttl <= 86_400, `TTL inattendu : ${ttl}`);
+
+    await assert.rejects(
+      () => first.execute("idem-sensitive-key", "payload-hash-b", operation),
+      IdempotencyConflictError,
+    );
+    assert.equal(evaluations, 1);
+  },
+);

--- a/api/src/infrastructure/redis-state-store.ts
+++ b/api/src/infrastructure/redis-state-store.ts
@@ -1,0 +1,367 @@
+import { createHmac, randomUUID } from "node:crypto";
+import { createClient, type RedisClientType } from "redis";
+import type { DecisionResponse } from "../decision.js";
+import type { IdempotencyStore, IdempotentResult } from "../idempotency-store.js";
+import type { VelocityStore } from "../velocity-store.js";
+import type { RateLimitCount } from "../rate-limit-store.js";
+import { CircuitBreaker, type CircuitState } from "./circuit-breaker.js";
+import { IdempotencyConflictError, StateStoreUnavailableError } from "./state-store-errors.js";
+
+const VELOCITY_SCRIPT = `
+local count = redis.call('INCR', KEYS[1])
+if count == 1 then
+  redis.call('EXPIRE', KEYS[1], ARGV[1])
+end
+return count
+`;
+
+const CLAIM_SCRIPT = `
+local response = redis.call('GET', KEYS[1])
+if response then
+  return {1, response}
+end
+local lock = redis.call('GET', KEYS[2])
+if lock then
+  return {2, lock}
+end
+redis.call('SET', KEYS[2], ARGV[1], 'PX', ARGV[2], 'NX')
+return {3, ''}
+`;
+
+const COMPLETE_SCRIPT = `
+if redis.call('GET', KEYS[2]) ~= ARGV[1] then
+  return 0
+end
+redis.call('SET', KEYS[1], ARGV[2], 'EX', ARGV[3])
+redis.call('DEL', KEYS[2])
+return 1
+`;
+
+const RELEASE_SCRIPT = `
+if redis.call('GET', KEYS[1]) == ARGV[1] then
+  return redis.call('DEL', KEYS[1])
+end
+return 0
+`;
+
+const RATE_LIMIT_SCRIPT = `
+local count = redis.call('INCR', KEYS[1])
+if count == 1 then
+  redis.call('PEXPIRE', KEYS[1], ARGV[1])
+end
+local ttl = redis.call('PTTL', KEYS[1])
+return {count, ttl}
+`;
+
+type CachedEnvelope = {
+  payloadHash: string;
+  decision: DecisionResponse;
+};
+
+type LockEnvelope = {
+  payloadHash: string;
+  token: string;
+};
+
+type ClaimReply = [number, string];
+
+export type RedisStateStoreOptions = Readonly<{
+  url: string;
+  hmacSecret: string;
+  velocityWindowSeconds: number;
+  commandTimeoutMs: number;
+  circuitFailureThreshold: number;
+  circuitResetMs: number;
+  idempotencyTtlSeconds: number;
+  idempotencyLockMs: number;
+  idempotencyWaitMs: number;
+  namespace?: string;
+  onCircuitTransition?: (from: CircuitState, to: CircuitState) => void;
+  onAvailabilityChange?: (from: SharedStateAvailability, to: SharedStateAvailability) => void;
+  onClientError?: (error: Error) => void;
+}>;
+
+export type SharedStateAvailability = "unknown" | "available" | "unavailable";
+
+class RedisExecutor {
+  readonly #client: RedisClientType;
+  readonly #breaker: CircuitBreaker;
+  readonly #onAvailability: (available: boolean) => void;
+  #connecting: Promise<void> | undefined;
+
+  constructor(
+    client: RedisClientType,
+    breaker: CircuitBreaker,
+    onAvailability: (available: boolean) => void,
+  ) {
+    this.#client = client;
+    this.#breaker = breaker;
+    this.#onAvailability = onAvailability;
+  }
+
+  async run<T>(operation: (client: RedisClientType) => Promise<T>): Promise<T> {
+    try {
+      const result = await this.#breaker.execute(async () => {
+        await this.#ensureConnected();
+        return operation(this.#client);
+      });
+      this.#onAvailability(true);
+      return result;
+    } catch (error) {
+      this.#onAvailability(false);
+      throw error;
+    }
+  }
+
+  close(): void {
+    if (this.#client.isOpen) this.#client.destroy();
+  }
+
+  async #ensureConnected(): Promise<void> {
+    if (this.#client.isReady) return;
+    if (this.#connecting === undefined) {
+      this.#connecting = this.#client
+        .connect()
+        .then(() => undefined)
+        .finally(() => {
+          this.#connecting = undefined;
+        });
+    }
+    await this.#connecting;
+    if (!this.#client.isReady) {
+      throw new StateStoreUnavailableError("Redis connection is not ready");
+    }
+  }
+}
+
+function parseJsonObject(raw: string, label: string): Record<string, unknown> {
+  try {
+    const value: unknown = JSON.parse(raw);
+    if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+      return value as Record<string, unknown>;
+    }
+  } catch (error) {
+    throw new StateStoreUnavailableError(`invalid ${label} JSON in Redis`, error);
+  }
+  throw new StateStoreUnavailableError(`invalid ${label} value in Redis`);
+}
+
+function parseLock(raw: string): LockEnvelope {
+  const value = parseJsonObject(raw, "idempotency lock");
+  if (typeof value.payloadHash !== "string" || typeof value.token !== "string") {
+    throw new StateStoreUnavailableError("invalid idempotency lock fields in Redis");
+  }
+  return { payloadHash: value.payloadHash, token: value.token };
+}
+
+function isDecisionResponse(value: unknown): value is DecisionResponse {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.decisionId === "string" &&
+    ["APPROVED", "REVIEW", "REJECTED"].includes(String(candidate.decision)) &&
+    typeof candidate.score === "number" &&
+    Array.isArray(candidate.reasons) &&
+    typeof candidate.evaluatedAt === "string" &&
+    typeof candidate.degraded === "boolean"
+  );
+}
+
+function parseCached(raw: string): CachedEnvelope {
+  const value = parseJsonObject(raw, "idempotency response");
+  if (typeof value.payloadHash !== "string" || !isDecisionResponse(value.decision)) {
+    throw new StateStoreUnavailableError("invalid idempotency response fields in Redis");
+  }
+  return { payloadHash: value.payloadHash, decision: value.decision };
+}
+
+function parseClaimReply(value: unknown): ClaimReply {
+  if (!Array.isArray(value) || value.length !== 2) {
+    throw new StateStoreUnavailableError("invalid idempotency claim reply from Redis");
+  }
+  const status = Number(value[0]);
+  const payload = String(value[1] ?? "");
+  if (![1, 2, 3].includes(status)) {
+    throw new StateStoreUnavailableError("unknown idempotency claim status from Redis");
+  }
+  return [status, payload];
+}
+
+export class RedisStateStore implements VelocityStore, IdempotencyStore {
+  readonly #options: RedisStateStoreOptions;
+  readonly #executor: RedisExecutor;
+  readonly #namespace: string;
+  #availability: SharedStateAvailability = "unknown";
+
+  constructor(options: RedisStateStoreOptions) {
+    this.#options = options;
+    this.#namespace = options.namespace ?? "trg";
+
+    const client = createClient({
+      url: options.url,
+      disableOfflineQueue: true,
+      commandsQueueMaxLength: 1_000,
+      socket: {
+        connectTimeout: options.commandTimeoutMs,
+        reconnectStrategy: false,
+      },
+    });
+    client.on("error", (error) => options.onClientError?.(error));
+
+    const breaker = new CircuitBreaker({
+      failureThreshold: options.circuitFailureThreshold,
+      resetAfterMs: options.circuitResetMs,
+      timeoutMs: options.commandTimeoutMs,
+      onTransition: options.onCircuitTransition,
+    });
+    this.#executor = new RedisExecutor(client, breaker, (available) => {
+      const next = available ? "available" : "unavailable";
+      if (next === this.#availability) return;
+      const previous = this.#availability;
+      this.#availability = next;
+      options.onAvailabilityChange?.(previous, next);
+    });
+  }
+
+  get availability(): SharedStateAvailability {
+    return this.#availability;
+  }
+
+  async probe(): Promise<void> {
+    await this.#executor.run((client) => client.ping());
+  }
+
+  async hit(cardId: string): Promise<number> {
+    const key = this.#key("velocity", cardId);
+    const reply = await this.#executor.run((client) =>
+      client.eval(VELOCITY_SCRIPT, {
+        keys: [key],
+        arguments: [String(this.#options.velocityWindowSeconds)],
+      }),
+    );
+    const count = Number(reply);
+    if (!Number.isInteger(count) || count < 1) {
+      throw new StateStoreUnavailableError("invalid velocity count returned by Redis");
+    }
+    return count;
+  }
+
+  async incrementRateLimit(key: string, timeWindowMs: number): Promise<RateLimitCount> {
+    const redisKey = this.#key("rate-limit", key);
+    const reply = await this.#executor.run((client) =>
+      client.eval(RATE_LIMIT_SCRIPT, {
+        keys: [redisKey],
+        arguments: [String(timeWindowMs)],
+      }),
+    );
+    if (!Array.isArray(reply) || reply.length !== 2) {
+      throw new StateStoreUnavailableError("invalid rate limit reply from Redis");
+    }
+    const current = Number(reply[0]);
+    const ttl = Number(reply[1]);
+    if (!Number.isInteger(current) || current < 1 || !Number.isInteger(ttl) || ttl < 1) {
+      throw new StateStoreUnavailableError("invalid rate limit values from Redis");
+    }
+    return { current, ttl };
+  }
+
+  async execute(
+    key: string,
+    payloadHash: string,
+    operation: () => Promise<DecisionResponse>,
+  ): Promise<IdempotentResult> {
+    return this.#executeUntil(
+      key,
+      payloadHash,
+      operation,
+      Date.now() + this.#options.idempotencyWaitMs,
+    );
+  }
+
+  close(): void {
+    this.#executor.close();
+  }
+
+  #key(
+    kind: "velocity" | "idempotency-response" | "idempotency-lock" | "rate-limit",
+    value: string,
+  ): string {
+    const digest = createHmac("sha256", this.#options.hmacSecret).update(value).digest("hex");
+    return `${this.#namespace}:${kind}:${digest}`;
+  }
+
+  async #executeUntil(
+    key: string,
+    payloadHash: string,
+    operation: () => Promise<DecisionResponse>,
+    deadline: number,
+  ): Promise<IdempotentResult> {
+    const responseKey = this.#key("idempotency-response", key);
+    const lockKey = this.#key("idempotency-lock", key);
+    const lock: LockEnvelope = { payloadHash, token: randomUUID() };
+    const serializedLock = JSON.stringify(lock);
+
+    const claim = parseClaimReply(
+      await this.#executor.run((client) =>
+        client.eval(CLAIM_SCRIPT, {
+          keys: [responseKey, lockKey],
+          arguments: [serializedLock, String(this.#options.idempotencyLockMs)],
+        }),
+      ),
+    );
+
+    if (claim[0] === 1) {
+      const cached = parseCached(claim[1]);
+      if (cached.payloadHash !== payloadHash) throw new IdempotencyConflictError();
+      return { decision: cached.decision, replayed: true };
+    }
+
+    if (claim[0] === 2) {
+      const pending = parseLock(claim[1]);
+      if (pending.payloadHash !== payloadHash) throw new IdempotencyConflictError();
+      if (Date.now() >= deadline) {
+        throw new StateStoreUnavailableError("timed out waiting for idempotent response");
+      }
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      return this.#executeUntil(key, payloadHash, operation, deadline);
+    }
+
+    try {
+      const decision = await operation();
+      const cached: CachedEnvelope = { payloadHash, decision };
+      const completed = Number(
+        await this.#executor.run((client) =>
+          client.eval(COMPLETE_SCRIPT, {
+            keys: [responseKey, lockKey],
+            arguments: [
+              serializedLock,
+              JSON.stringify(cached),
+              String(this.#options.idempotencyTtlSeconds),
+            ],
+          }),
+        ),
+      );
+      if (completed !== 1) {
+        throw new StateStoreUnavailableError("idempotency lock expired before completion");
+      }
+      return { decision, replayed: false };
+    } catch (error) {
+      await this.#releaseLock(lockKey, serializedLock);
+      throw error;
+    }
+  }
+
+  async #releaseLock(lockKey: string, serializedLock: string): Promise<void> {
+    try {
+      await this.#executor.run((client) =>
+        client.eval(RELEASE_SCRIPT, {
+          keys: [lockKey],
+          arguments: [serializedLock],
+        }),
+      );
+    } catch {
+      // Le verrou possède toujours un TTL : une panne de cleanup ne peut pas
+      // créer un verrou permanent et ne masque pas l'erreur initiale.
+    }
+  }
+}

--- a/api/src/infrastructure/state-store-errors.ts
+++ b/api/src/infrastructure/state-store-errors.ts
@@ -1,0 +1,16 @@
+export class StateStoreUnavailableError extends Error {
+  override readonly cause: unknown;
+
+  constructor(message: string, cause?: unknown) {
+    super(message);
+    this.name = "StateStoreUnavailableError";
+    this.cause = cause;
+  }
+}
+
+export class IdempotencyConflictError extends Error {
+  constructor() {
+    super("the idempotency key is already associated with another payload");
+    this.name = "IdempotencyConflictError";
+  }
+}

--- a/api/src/rate-limit-store.test.ts
+++ b/api/src/rate-limit-store.test.ts
@@ -1,0 +1,42 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createRateLimitStore, type SharedRateLimitCounter } from "./rate-limit-store.js";
+
+const increment = (store: InstanceType<ReturnType<typeof createRateLimitStore>>, key: string) =>
+  new Promise<{ current: number; ttl: number }>((resolve, reject) => {
+    store.incr(
+      key,
+      (error, result) => {
+        if (error !== null) return reject(error);
+        if (result === undefined) return reject(new Error("missing rate limit result"));
+        resolve(result);
+      },
+      60_000,
+      10,
+    );
+  });
+
+test("rate limit adapter delegates to the shared counter", async () => {
+  const counter: SharedRateLimitCounter = {
+    incrementRateLimit: async () => ({ current: 7, ttl: 12_000 }),
+  };
+  const Store = createRateLimitStore(counter, () => assert.fail("unexpected fallback"));
+  const store = new Store({});
+
+  assert.deepEqual(await increment(store, "public:127.0.0.1"), { current: 7, ttl: 12_000 });
+});
+
+test("Redis failure keeps a bounded local rate limit active", async () => {
+  let fallbacks = 0;
+  const counter: SharedRateLimitCounter = {
+    incrementRateLimit: () => Promise.reject(new Error("Redis unavailable")),
+  };
+  const Store = createRateLimitStore(counter, () => {
+    fallbacks += 1;
+  });
+  const store = new Store({});
+
+  assert.equal((await increment(store, "public:127.0.0.1")).current, 1);
+  assert.equal((await increment(store, "public:127.0.0.1")).current, 2);
+  assert.equal(fallbacks, 2);
+});

--- a/api/src/rate-limit-store.ts
+++ b/api/src/rate-limit-store.ts
@@ -1,0 +1,66 @@
+import type { FastifyRateLimitStore, FastifyRateLimitStoreCtor } from "@fastify/rate-limit";
+
+export type RateLimitCount = Readonly<{ current: number; ttl: number }>;
+
+export interface SharedRateLimitCounter {
+  incrementRateLimit(key: string, timeWindowMs: number): Promise<RateLimitCount>;
+}
+
+class LocalFallbackCounter {
+  readonly #windows = new Map<string, { current: number; expiresAt: number }>();
+  readonly #maxKeys: number;
+
+  constructor(maxKeys = 10_000) {
+    this.#maxKeys = maxKeys;
+  }
+
+  increment(key: string, timeWindowMs: number, now = Date.now()): RateLimitCount {
+    const existing = this.#windows.get(key);
+    if (existing === undefined || existing.expiresAt <= now) {
+      this.#evictIfNeeded();
+      this.#windows.set(key, { current: 1, expiresAt: now + timeWindowMs });
+      return { current: 1, ttl: timeWindowMs };
+    }
+    existing.current += 1;
+    return { current: existing.current, ttl: Math.max(1, existing.expiresAt - now) };
+  }
+
+  #evictIfNeeded(): void {
+    if (this.#windows.size < this.#maxKeys) return;
+    const oldest = this.#windows.keys().next().value as string | undefined;
+    if (oldest !== undefined) this.#windows.delete(oldest);
+  }
+}
+
+/**
+ * Adapte le compteur Redis à @fastify/rate-limit. Si l'état partagé tombe,
+ * une limite locale bornée reste active : la protection ne disparaît jamais,
+ * même si sa portée devient temporairement celle d'un replica.
+ */
+export function createRateLimitStore(
+  counter: SharedRateLimitCounter,
+  onFallback: () => void,
+): FastifyRateLimitStoreCtor {
+  const fallback = new LocalFallbackCounter();
+
+  return class SharedStore implements FastifyRateLimitStore {
+    incr(
+      key: string,
+      callback: (error: Error | null, result?: RateLimitCount) => void,
+      timeWindow: number,
+      _max: number,
+    ): void {
+      counter.incrementRateLimit(key, timeWindow).then(
+        (result) => callback(null, result),
+        () => {
+          onFallback();
+          callback(null, fallback.increment(key, timeWindow));
+        },
+      );
+    }
+
+    child(): FastifyRateLimitStore {
+      return this;
+    }
+  };
+}

--- a/api/src/velocity-store.test.ts
+++ b/api/src/velocity-store.test.ts
@@ -1,0 +1,36 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { InMemoryVelocityStore } from "./velocity-store.js";
+
+test("counts successive occurrences within the window", async () => {
+  const store = new InMemoryVelocityStore(60, () => 0);
+  assert.equal(await store.hit("card_1"), 1);
+  assert.equal(await store.hit("card_1"), 2);
+  assert.equal(await store.hit("card_1"), 3);
+});
+
+test("cards are counted independently", async () => {
+  const store = new InMemoryVelocityStore(60, () => 0);
+  assert.equal(await store.hit("card_1"), 1);
+  assert.equal(await store.hit("card_2"), 1);
+  assert.equal(await store.hit("card_1"), 2);
+});
+
+test("the counter resets after the window (fixed window)", async () => {
+  let now = 0;
+  const store = new InMemoryVelocityStore(60, () => now);
+  await store.hit("card_1");
+  await store.hit("card_1");
+  now = 60_000;
+  assert.equal(await store.hit("card_1"), 1);
+});
+
+test("the window does not slide: a late hit does not extend it", async () => {
+  let now = 0;
+  const store = new InMemoryVelocityStore(60, () => now);
+  await store.hit("card_1"); // resetAt = 60_000
+  now = 59_000;
+  assert.equal(await store.hit("card_1"), 2); // same window
+  now = 60_000;
+  assert.equal(await store.hit("card_1"), 1); // reset, not 3
+});

--- a/api/src/velocity-store.ts
+++ b/api/src/velocity-store.ts
@@ -1,0 +1,51 @@
+/**
+ * Source de vérité du compteur de vélocité. C'est le *seam* du projet : la
+ * règle VELOCITY ne dépend que de cette interface, jamais d'une implémentation.
+ * Passer à Redis = un nouveau fichier `redis-velocity-store.ts` + une variable
+ * d'environnement, sans toucher aux règles.
+ */
+export interface VelocityStore {
+  /**
+   * Enregistre une occurrence pour cette carte et renvoie le nombre
+   * d'occurrences dans la fenêtre courante, celle-ci comprise.
+   */
+  hit(cardId: string): Promise<number>;
+}
+
+type Window = { count: number; resetAt: number };
+
+/**
+ * Compteur en mémoire à **fenêtre fixe** — volontairement la même sémantique
+ * que Redis `INCR` + `EXPIRE` : le compteur d'une carte repart de zéro à
+ * l'expiration de sa fenêtre, il ne glisse pas. Ainsi le passage à Redis
+ * préserve le comportement de détection, pas seulement l'interface.
+ *
+ * Limites assumées, toutes résolues par l'implémentation Redis :
+ *  - non partagé : chaque replica a son propre compteur (c'est LE défaut que le
+ *    projet met en scène) ;
+ *  - les cartes jamais revues gardent une entrée jusqu'au redémarrage.
+ */
+export class InMemoryVelocityStore implements VelocityStore {
+  readonly #windows = new Map<string, Window>();
+  readonly #windowMs: number;
+  readonly #now: () => number;
+
+  // `now` injectable pour tester l'expiration de fenêtre sans horloge réelle.
+  constructor(windowSeconds: number, now: () => number = () => Date.now()) {
+    this.#windowMs = windowSeconds * 1000;
+    this.#now = now;
+  }
+
+  async hit(cardId: string): Promise<number> {
+    const now = this.#now();
+    const current = this.#windows.get(cardId);
+
+    if (current === undefined || now >= current.resetAt) {
+      this.#windows.set(cardId, { count: 1, resetAt: now + this.#windowMs });
+      return 1;
+    }
+
+    current.count += 1;
+    return current.count;
+  }
+}


### PR DESCRIPTION
## Résultat attendu

Un état cohérent entre replicas — vélocité et idempotence — porté par Redis avec des opérations
atomiques, tout en restant **sûr quand Redis est indisponible** : le service force `REVIEW`,
`degraded: true`, et ne produit **jamais** `APPROVED` sur une information de risque inconnue.

## Travail et périmètre

- Issue : `TRG-3` / #12
- Branche source : `feat/TRG-3-coherence-redis` → `develop`
- Labels : `type:feat`, `risk:high`, `area:api`, `area:redis`, `release:required`
- Inclus : seams `VelocityStore` / `IdempotencyStore` / `RateLimitStore` (+ implémentations mémoire),
  `RedisStateStore` (compteur `INCR`+`EXPIRE`, HMAC-SHA256 du `cardId` avant toute clé, idempotence
  24 h + `409 idempotency_conflict`, single-flight), `CircuitBreaker` (timeout 250 ms configurable),
  `evaluateDegradedRisk` fail-safe. Service Redis ajouté au job `Tests existants`.
- Exclu : routes HTTP, `config` de production câblée, web — tranches suivantes.

## Risques et compatibilité

- Niveau de risque : high — cœur de la cohérence distribuée et de la sécurité fail-safe.
- Impact API : nouveaux modules, aucune route encore exposée.
- Rollback : `develop` reste vert sans cette PR.

## Vérification

- `npm run test:coverage --prefix api` (service Redis) : **54 tests**, **95,8 % lignes** (seuil 80),
  branches 87,9 %.
- `npm run test:coverage:domain --prefix api` : 99,2 % (seuil 90).
- Cas couverts : Redis réel, concurrence (single-flight), expiration TTL, conflit d'idempotence,
  panne Redis et rétablissement, ouverture/fermeture du circuit breaker.
- `prettier`, `markdownlint`, `validate-repository`, `pre-commit`, `pre-push` : verts.

## Notes pour le reviewer

Le `cardId` n'apparaît jamais en clair dans Redis (HMAC-SHA256 avec sel dédié). La politique
fail-safe est testée explicitement : décision dégradée `REVIEW` score ≥ 30, puis `APPROVED`
non dégradé après rétablissement.

Closes #12
