### PR TITLE
[TRG-4] sécuriser et observer l'API transactionnelle

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -1,0 +1,264 @@
+import { randomUUID } from "node:crypto";
+import Fastify, { LogController, type FastifyError, type FastifyInstance } from "fastify";
+import rateLimit from "@fastify/rate-limit";
+import type { FastifyRateLimitStoreCtor } from "@fastify/rate-limit";
+import type { Config } from "./config.js";
+import type { VelocityStore } from "./velocity-store.js";
+import type { IdempotencyStore } from "./idempotency-store.js";
+import type { Metrics } from "./metrics.js";
+import type { Readiness } from "./readiness.js";
+import { keyIsValid, registerApiKeyAuth } from "./auth.js";
+import { registerDecisions } from "./decisions.js";
+import { describeRules } from "./domain/risk-engine.js";
+import { createLoggerOptions } from "./observability.js";
+
+const REQUEST_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,63}$/;
+
+export type RateLimitProfile = "public" | "load";
+
+function validRequestId(value: unknown): value is string {
+  return typeof value === "string" && REQUEST_ID_PATTERN.test(value);
+}
+
+export function rateLimitProfile(
+  headers: Record<string, unknown>,
+  config: Config,
+): RateLimitProfile {
+  const provided = headers["x-load-test-token"];
+  if (
+    config.appEnvironment !== "production" &&
+    config.loadTestToken !== undefined &&
+    typeof provided === "string" &&
+    keyIsValid(provided, config.loadTestToken)
+  ) {
+    return "load";
+  }
+  return "public";
+}
+
+/** Tout ce dont l'application a besoin, injecté depuis `server.ts` (ou les tests). */
+export type AppDeps = {
+  config: Config;
+  velocityStore: VelocityStore;
+  idempotencyStore: IdempotencyStore;
+  metrics: Metrics;
+  readiness: Readiness;
+  instanceId: string;
+  sharedStateStatus?: () => "unknown" | "available" | "unavailable";
+  rateLimitStore?: FastifyRateLimitStoreCtor;
+};
+
+/**
+ * Fabrique l'instance Fastify et enregistre les routes.
+ * Séparée de `server.ts` pour permettre `app.inject()` en test sans socket.
+ */
+export function buildApp(deps: AppDeps): FastifyInstance {
+  const app = Fastify({
+    logger: createLoggerOptions(deps.config, deps.instanceId),
+    logController: new LogController({
+      disableRequestLogging: true,
+      requestIdLogLabel: "requestId",
+    }),
+    bodyLimit: deps.config.bodyLimitBytes,
+    connectionTimeout: deps.config.connectionTimeoutMs,
+    requestTimeout: deps.config.requestTimeoutMs,
+    keepAliveTimeout: deps.config.keepAliveTimeoutMs,
+    maxRequestsPerSocket: deps.config.maxRequestsPerSocket,
+    routerOptions: { maxParamLength: 64 },
+    trustProxy:
+      deps.config.trustProxyHops === 0
+        ? false
+        : (_address: string, hop: number) => hop < deps.config.trustProxyHops,
+    // Réutilise l'id fourni par un proxy/nginx s'il existe, sinon en génère un.
+    genReqId: (req) => {
+      const header = req.headers["x-request-id"];
+      return validRequestId(header) ? header : randomUUID();
+    },
+  });
+
+  const pendingRequests = new WeakSet<object>();
+  const finishRequest = (request: object) => {
+    if (!pendingRequests.has(request)) return;
+    pendingRequests.delete(request);
+    deps.metrics.requestFinished();
+  };
+
+  app.addHook("onRequest", (request, reply, done) => {
+    pendingRequests.add(request);
+    deps.metrics.requestStarted();
+
+    // Quel conteneur traite la requête (interface : compte des replicas) + trace.
+    reply.header("X-Instance-Id", deps.instanceId);
+    reply.header("X-Request-Id", request.id);
+
+    const rawRequestId = request.headers["x-request-id"];
+    if (rawRequestId !== undefined && !validRequestId(rawRequestId)) {
+      deps.metrics.recordRequestFailure("invalid_request_id");
+      request.log.warn(
+        { event: "request_rejected", reason: "invalid_request_id" },
+        "unsafe request identifier rejected",
+      );
+      void reply.code(400).send({ error: "invalid_request_id" });
+      return;
+    }
+
+    const loadToken = request.headers["x-load-test-token"];
+    if (
+      loadToken !== undefined &&
+      (typeof loadToken !== "string" || loadToken.length < 32 || loadToken.length > 256)
+    ) {
+      deps.metrics.recordRequestFailure("invalid_load_test_token");
+      request.log.warn(
+        { event: "request_rejected", reason: "invalid_load_test_token" },
+        "invalid load test token header rejected",
+      );
+      void reply.code(400).send({ error: "invalid_load_test_token" });
+      return;
+    }
+    done();
+  });
+
+  app.addHook("onResponse", (request, reply, done) => {
+    finishRequest(request);
+    deps.metrics.recordHttpRequest({
+      method: request.method,
+      route: request.routeOptions.url ?? "unmatched",
+      statusCode: reply.statusCode,
+      durationSeconds: reply.elapsedTime / 1000,
+    });
+    request.log.info(
+      {
+        event: "http_request_completed",
+        method: request.method,
+        route: request.routeOptions.url ?? "unmatched",
+        statusCode: reply.statusCode,
+        durationMs: Math.round(reply.elapsedTime),
+      },
+      "HTTP request completed",
+    );
+    done();
+  });
+
+  app.addHook("onRequestAbort", (request, done) => {
+    finishRequest(request);
+    deps.metrics.recordRequestAborted("aborted");
+    request.log.warn({ event: "http_request_aborted" }, "request aborted");
+    done();
+  });
+
+  app.addHook("onTimeout", (request, _reply, done) => {
+    finishRequest(request);
+    deps.metrics.recordRequestAborted("timeout");
+    request.log.warn({ event: "http_request_timeout" }, "request timed out");
+    done();
+  });
+
+  app.addHook("onSend", (_request, reply, payload, done) => {
+    reply.header("Cache-Control", "no-store");
+    reply.header("X-Content-Type-Options", "nosniff");
+    reply.header("X-Frame-Options", "DENY");
+    reply.header("Referrer-Policy", "no-referrer");
+    reply.header("Content-Security-Policy", "default-src 'none'; frame-ancestors 'none'");
+    done(null, payload);
+  });
+
+  app.setErrorHandler((error: FastifyError, request, reply) => {
+    const clientError =
+      typeof error.statusCode === "number" && error.statusCode >= 400 && error.statusCode < 500;
+    const code =
+      error.code === "FST_ERR_CTP_BODY_TOO_LARGE"
+        ? "payload_too_large"
+        : error.statusCode === 429
+          ? "rate_limit_exceeded"
+          : clientError
+            ? "invalid_request"
+            : "request_failed";
+    const statusCode =
+      code === "payload_too_large"
+        ? 413
+        : code === "rate_limit_exceeded"
+          ? 429
+          : clientError
+            ? (error.statusCode ?? 400)
+            : 500;
+    deps.metrics.recordRequestFailure(code);
+    const level = statusCode >= 500 ? "error" : "warn";
+    request.log[level](
+      { event: "request_failed", code, statusCode, errorType: error.name },
+      "request processing failed",
+    );
+    return reply
+      .code(statusCode >= 400 && statusCode < 600 ? statusCode : 500)
+      .send({ error: code });
+  });
+
+  // Les routes vivent dans le même contexte que le plugin. L'enregistrement
+  // asynchrone garantit que le hook de rate limiting existe avant les routes.
+  app.register(async (routes) => {
+    await routes.register(rateLimit, {
+      global: true,
+      hook: "onRequest",
+      timeWindow: deps.config.rateLimitWindowMs,
+      max: (request) =>
+        rateLimitProfile(request.headers, deps.config) === "load"
+          ? deps.config.rateLimitLoadMax
+          : deps.config.rateLimitMax,
+      keyGenerator: (request) => `${rateLimitProfile(request.headers, deps.config)}:${request.ip}`,
+      allowList: (request) => !request.url.startsWith("/api/"),
+      enableDraftSpec: true,
+      skipOnError: false,
+      ...(deps.rateLimitStore === undefined ? {} : { store: deps.rateLimitStore }),
+      onExceeded: (request) => {
+        const profile = rateLimitProfile(request.headers, deps.config);
+        deps.metrics.recordRateLimitExceeded(profile);
+        request.log.warn({ event: "rate_limit_exceeded", profile }, "request rate limited");
+      },
+    });
+
+    // Le rate limiter précède l'authentification pour compter aussi les tentatives
+    // invalides et limiter les attaques par force brute.
+    registerApiKeyAuth(routes, deps.config.apiKey, () => deps.metrics.recordAuthFailure());
+
+    routes.addHook("preValidation", (request, reply, done) => {
+      if (request.routeOptions.url === "/api/decisions" && request.method === "POST") {
+        const contentType = request.headers["content-type"]?.split(";", 1)[0]?.trim().toLowerCase();
+        if (contentType !== "application/json") {
+          deps.metrics.recordRequestFailure("unsupported_media_type");
+          void reply.code(415).send({ error: "unsupported_media_type" });
+          return;
+        }
+      }
+      if (request.url.includes("?")) {
+        deps.metrics.recordRequestFailure("unexpected_query");
+        void reply.code(400).send({ error: "unexpected_query" });
+        return;
+      }
+      done();
+    });
+
+    // Liveness : le process répond-il ? Ne teste aucune dépendance externe.
+    routes.get("/health", async () => ({ status: "ok" }));
+
+    routes.get("/ready", async (_request, reply) => {
+      if (deps.readiness.isReady()) {
+        const redis = deps.sharedStateStatus?.() ?? "available";
+        return {
+          status: "ready",
+          mode: redis === "available" ? "normal" : "degraded",
+          dependencies: { redis },
+        };
+      }
+      return reply.code(503).send({ status: "shutting_down" });
+    });
+
+    routes.get("/metrics", async (_request, reply) => {
+      reply.header("Content-Type", deps.metrics.registry.contentType);
+      return deps.metrics.registry.metrics();
+    });
+
+    routes.get("/api/rules", async () => describeRules(deps.config));
+    registerDecisions(routes, deps);
+  });
+
+  return app;
+}

--- a/api/src/auth.test.ts
+++ b/api/src/auth.test.ts
@@ -1,0 +1,73 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { buildApp } from "./app.js";
+import { keyIsValid } from "./auth.js";
+import { postDecision, testDeps } from "./test-helpers.js";
+
+const validBody = {
+  transactionId: "txn_1",
+  cardId: "card_1",
+  amount: 20,
+  currency: "EUR",
+  country: "FR",
+  channel: "in_store",
+  merchantCategory: "grocery",
+};
+
+test("keyIsValid: exact match only, undefined and mismatched length are rejected", () => {
+  assert.equal(keyIsValid("secret", "secret"), true);
+  assert.equal(keyIsValid("secret", "other"), false);
+  assert.equal(keyIsValid("sec", "secret"), false);
+  assert.equal(keyIsValid(undefined, "secret"), false);
+});
+
+test("POST /api/decisions without X-API-Key is 401", async (t) => {
+  const app = buildApp(testDeps());
+  t.after(() => app.close());
+
+  const response = await app.inject({
+    method: "POST",
+    url: "/api/decisions",
+    payload: JSON.stringify(validBody),
+    headers: { "content-type": "application/json" },
+  });
+
+  assert.equal(response.statusCode, 401);
+  assert.equal(response.json().error, "unauthorized");
+});
+
+test("POST /api/decisions with a wrong X-API-Key is 401", async (t) => {
+  const app = buildApp(testDeps());
+  t.after(() => app.close());
+
+  const response = await app.inject(postDecision(validBody, { "x-api-key": "wrong" }));
+  assert.equal(response.statusCode, 401);
+});
+
+test("POST /api/decisions with the right X-API-Key is 200", async (t) => {
+  const app = buildApp(testDeps());
+  t.after(() => app.close());
+
+  const response = await app.inject(postDecision(validBody));
+  assert.equal(response.statusCode, 200);
+});
+
+test("a 401 still carries X-Instance-Id and X-Request-Id", async (t) => {
+  const app = buildApp(testDeps());
+  t.after(() => app.close());
+
+  const response = await app.inject({ method: "POST", url: "/api/decisions" });
+  assert.equal(response.statusCode, 401);
+  assert.equal(response.headers["x-instance-id"], "test-instance");
+  assert.ok(response.headers["x-request-id"]);
+});
+
+for (const probe of ["/health", "/ready", "/metrics"]) {
+  test(`${probe} stays open without an API key`, async (t) => {
+    const app = buildApp(testDeps());
+    t.after(() => app.close());
+
+    const response = await app.inject({ method: "GET", url: probe });
+    assert.notEqual(response.statusCode, 401);
+  });
+}

--- a/api/src/auth.ts
+++ b/api/src/auth.ts
@@ -1,0 +1,37 @@
+import { createHash, timingSafeEqual } from "node:crypto";
+import type { FastifyInstance } from "fastify";
+
+// Comparaison à temps constant : `===` sur une chaîne révèle, par le temps de
+// réponse, la longueur et le plus long préfixe correct. On compare des hachages
+// SHA-256 (toujours 32 octets, d'où pas de fuite de longueur).
+const digest = (value: string): Buffer => createHash("sha256").update(value).digest();
+
+export function keyIsValid(provided: string | undefined, expected: string): boolean {
+  if (provided === undefined) return false;
+  return timingSafeEqual(digest(provided), digest(expected));
+}
+
+/**
+ * Exige l'en-tête `X-API-Key` sur tout ce qui est sous `/api/`. Le reste
+ * (`/health`, `/ready`, `/metrics`, routes hors `/api/`) passe sans clé : les
+ * sondes de la plateforme n'envoient aucun en-tête, un 401 les ferait boucler.
+ */
+export function registerApiKeyAuth(
+  app: FastifyInstance,
+  apiKey: string,
+  onDenied: () => void,
+): void {
+  app.addHook("onRequest", (request, reply, done) => {
+    if (!request.url.startsWith("/api/")) return done();
+
+    const provided = request.headers["x-api-key"];
+    if (typeof provided === "string" && keyIsValid(provided, apiKey)) return done();
+
+    onDenied();
+    request.log.warn(
+      { event: "authentication_denied", reason: "missing_or_invalid_api_key" },
+      "interservice authentication denied",
+    );
+    reply.code(401).send({ error: "unauthorized" });
+  });
+}

--- a/api/src/decisions.test.ts
+++ b/api/src/decisions.test.ts
@@ -1,0 +1,225 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { buildApp } from "./app.js";
+import { InMemoryVelocityStore } from "./velocity-store.js";
+import type { VelocityStore } from "./velocity-store.js";
+import { TEST_API_KEY, postDecision, testDeps } from "./test-helpers.js";
+import { StateStoreUnavailableError } from "./infrastructure/state-store-errors.js";
+
+const authGet = (url: string) => ({
+  method: "GET" as const,
+  url,
+  headers: { "x-api-key": TEST_API_KEY },
+});
+
+const validBody = {
+  transactionId: "txn_1",
+  cardId: "card_1",
+  amount: 20,
+  currency: "EUR",
+  country: "FR",
+  channel: "in_store",
+  merchantCategory: "grocery",
+};
+
+test("returns a full decision for a valid transaction", async (t) => {
+  const app = buildApp(testDeps());
+  t.after(() => app.close());
+
+  const response = await app.inject(postDecision(validBody));
+  assert.equal(response.statusCode, 200);
+
+  const decision = response.json();
+  assert.match(decision.decisionId, /^dec_[0-9a-f-]{36}$/);
+  assert.equal(decision.decision, "APPROVED");
+  assert.equal(decision.score, 0);
+  assert.equal(typeof decision.evaluatedAt, "string");
+  assert.equal(decision.degraded, false);
+});
+
+test("rejects an invalid body with 400", async (t) => {
+  const app = buildApp(testDeps());
+  t.after(() => app.close());
+
+  const response = await app.inject(postDecision({ cardId: "card_1" }));
+  assert.equal(response.statusCode, 400);
+  assert.equal(response.json().error, "invalid_transaction");
+});
+
+test("normalizes the body: a lowercase country still matches the allowed list", async (t) => {
+  const app = buildApp(testDeps());
+  t.after(() => app.close());
+
+  const response = await app.inject(postDecision({ ...validBody, country: "fr" }));
+  assert.equal(response.json().decision, "APPROVED");
+});
+
+test("rejects a non-EUR transaction", async (t) => {
+  const app = buildApp(testDeps());
+  t.after(() => app.close());
+
+  const response = await app.inject(postDecision({ ...validBody, currency: "USD" }));
+  assert.equal(response.statusCode, 400);
+  assert.equal(response.json().error, "invalid_transaction");
+});
+
+test("returns generic reasons without transaction values", async (t) => {
+  const app = buildApp(testDeps());
+  t.after(() => app.close());
+
+  const response = await app.inject(
+    postDecision({
+      ...validBody,
+      amount: 9876,
+      country: "US",
+      channel: "online",
+      merchantCategory: "crypto",
+    }),
+  );
+  assert.equal(response.statusCode, 200);
+
+  const serializedReasons = JSON.stringify(response.json().reasons);
+  for (const sensitiveValue of ["card_1", "txn_1", "US", "9876", "crypto"]) {
+    assert.doesNotMatch(serializedReasons, new RegExp(sensitiveValue, "i"));
+  }
+});
+
+test("same Idempotency-Key returns the exact same decision", async (t) => {
+  const app = buildApp(testDeps());
+  t.after(() => app.close());
+
+  const headers = { "idempotency-key": "idem-key-123" };
+  const first = await app.inject(postDecision(validBody, headers));
+  const second = await app.inject(postDecision(validBody, headers));
+
+  assert.deepEqual(second.json(), first.json());
+});
+
+test("an idempotent replay does not increment the velocity counter", async (t) => {
+  let hits = 0;
+  const countingStore: VelocityStore = {
+    hit: async () => {
+      hits += 1;
+      return hits;
+    },
+  };
+  const app = buildApp(testDeps({ velocityStore: countingStore }));
+  t.after(() => app.close());
+
+  const headers = { "idempotency-key": "idem-key-abc" };
+  await app.inject(postDecision(validBody, headers));
+  await app.inject(postDecision(validBody, headers));
+
+  assert.equal(hits, 1);
+});
+
+test("concurrent identical requests execute the evaluation only once", async (t) => {
+  let hits = 0;
+  const countingStore: VelocityStore = {
+    hit: async () => {
+      hits += 1;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      return hits;
+    },
+  };
+  const app = buildApp(testDeps({ velocityStore: countingStore }));
+  t.after(() => app.close());
+
+  const responses = await Promise.all(
+    Array.from({ length: 10 }, () =>
+      app.inject(postDecision(validBody, { "idempotency-key": "idem-concurrent-1" })),
+    ),
+  );
+
+  assert.equal(hits, 1);
+  assert.ok(responses.every((response) => response.statusCode === 200));
+  assert.equal(new Set(responses.map((response) => response.json().decisionId)).size, 1);
+});
+
+test("same Idempotency-Key with another payload returns 409", async (t) => {
+  const app = buildApp(testDeps());
+  t.after(() => app.close());
+
+  const headers = { "idempotency-key": "idem-conflict-1" };
+  await app.inject(postDecision(validBody, headers));
+  const response = await app.inject(postDecision({ ...validBody, amount: 21 }, headers));
+
+  assert.equal(response.statusCode, 409);
+  assert.equal(response.json().error, "idempotency_conflict");
+});
+
+test("invalid Idempotency-Key returns 400", async (t) => {
+  const app = buildApp(testDeps());
+  t.after(() => app.close());
+
+  const response = await app.inject(postDecision(validBody, { "idempotency-key": "bad key" }));
+  assert.equal(response.statusCode, 400);
+  assert.equal(response.json().error, "invalid_idempotency_key");
+});
+
+test("shared state outage forces REVIEW and degraded=true", async (t) => {
+  const unavailableStore: VelocityStore = {
+    hit: () => Promise.reject(new StateStoreUnavailableError("Redis unavailable")),
+  };
+  const app = buildApp(testDeps({ velocityStore: unavailableStore }));
+  t.after(() => app.close());
+
+  const response = await app.inject(postDecision(validBody));
+  const decision = response.json();
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.headers["x-degraded-mode"], "true");
+  assert.equal(decision.decision, "REVIEW");
+  assert.equal(decision.degraded, true);
+  assert.ok(decision.score >= 30);
+  assert.equal(decision.reasons.at(-1).rule, "RISK_CONTEXT_UNAVAILABLE");
+});
+
+test("without an Idempotency-Key, each call is evaluated afresh", async (t) => {
+  const velocityStore = new InMemoryVelocityStore(60, () => 0);
+  const app = buildApp(testDeps({ velocityStore }));
+  t.after(() => app.close());
+
+  const first = await app.inject(postDecision(validBody));
+  const second = await app.inject(postDecision(validBody));
+
+  assert.notEqual(first.json().decisionId, second.json().decisionId);
+});
+
+test("GET /api/decisions is not exposed", async (t) => {
+  const app = buildApp(testDeps());
+  t.after(() => app.close());
+
+  const response = await app.inject(authGet("/api/decisions"));
+  assert.equal(response.statusCode, 404);
+});
+
+test("GET /api/rules exposes the active weights, bands and thresholds", async (t) => {
+  const app = buildApp(testDeps());
+  t.after(() => app.close());
+
+  const response = await app.inject(authGet("/api/rules"));
+  assert.equal(response.statusCode, 200);
+
+  const view = response.json();
+  assert.equal(view.currency, "EUR");
+  assert.equal(view.maxScore, 100);
+  assert.deepEqual(view.scoreBands, {
+    approved: { min: 0, max: 29 },
+    review: { min: 30, max: 59 },
+    rejected: { min: 60, max: 100 },
+  });
+  assert.equal(view.rules.length, 5);
+  assert.equal(
+    view.rules.find((r: { rule: string }) => r.rule === "AMOUNT_THRESHOLD").parameters.threshold,
+    1000,
+  );
+});
+
+test("GET /api/rules requires the API key", async (t) => {
+  const app = buildApp(testDeps());
+  t.after(() => app.close());
+
+  const response = await app.inject({ method: "GET", url: "/api/rules" });
+  assert.equal(response.statusCode, 401);
+});

--- a/api/src/decisions.ts
+++ b/api/src/decisions.ts
@@ -1,0 +1,140 @@
+import { createHash, randomUUID } from "node:crypto";
+import type { FastifyInstance } from "fastify";
+import { z } from "zod";
+import type { AppDeps } from "./app.js";
+import type { DecisionResponse } from "./decision.js";
+import { TransactionSchema } from "./domain/transaction.js";
+import { evaluateTransaction } from "./application/evaluate-transaction.js";
+import { evaluateDegradedRisk, type Evaluation } from "./domain/risk-engine.js";
+import {
+  IdempotencyConflictError,
+  StateStoreUnavailableError,
+} from "./infrastructure/state-store-errors.js";
+
+function newDecisionId(): string {
+  return `dec_${randomUUID()}`;
+}
+
+const IdempotencyKeySchema = z
+  .string()
+  .trim()
+  .min(8)
+  .max(128)
+  .regex(/^[A-Za-z0-9._:-]+$/);
+
+/** La ligne de journal qui sert de piste d'audit d'une décision. */
+export function toAuditRecord(decision: DecisionResponse) {
+  return {
+    audit: "decision" as const,
+    decisionId: decision.decisionId,
+    decision: decision.decision,
+    score: decision.score,
+    reasons: decision.reasons.map((reason) => reason.rule),
+    degraded: decision.degraded,
+  };
+}
+
+function hashTransactionPayload(transaction: object): string {
+  return createHash("sha256").update(JSON.stringify(transaction)).digest("hex");
+}
+
+function toDecisionResponse(evaluation: Evaluation): DecisionResponse {
+  return {
+    decisionId: newDecisionId(),
+    decision: evaluation.decision,
+    score: evaluation.score,
+    reasons: evaluation.reasons,
+    evaluatedAt: new Date().toISOString(),
+    degraded: evaluation.degraded,
+  };
+}
+
+export function registerDecisions(app: FastifyInstance, deps: AppDeps): void {
+  app.post("/api/decisions", async (request, reply) => {
+    const parsed = TransactionSchema.safeParse(request.body);
+    if (!parsed.success) {
+      deps.metrics.recordRequestFailure("invalid_transaction");
+      request.log.warn(
+        { event: "request_rejected", reason: "invalid_transaction" },
+        "transaction validation failed",
+      );
+      return reply.code(400).send({
+        error: "invalid_transaction",
+        details: parsed.error.issues.map((issue) => ({
+          path: issue.path.join("."),
+          message: issue.message,
+        })),
+      });
+    }
+
+    const rawIdempotencyKey = request.headers["idempotency-key"];
+    const parsedKey =
+      rawIdempotencyKey === undefined
+        ? { success: true as const, data: null }
+        : IdempotencyKeySchema.safeParse(rawIdempotencyKey);
+    if (!parsedKey.success) {
+      deps.metrics.recordRequestFailure("invalid_idempotency_key");
+      request.log.warn(
+        { event: "request_rejected", reason: "invalid_idempotency_key" },
+        "idempotency header validation failed",
+      );
+      return reply.code(400).send({
+        error: "invalid_idempotency_key",
+        message: "Idempotency-Key doit contenir 8 à 128 caractères sûrs",
+      });
+    }
+
+    const renderDecision = async () =>
+      toDecisionResponse(await evaluateTransaction(parsed.data, deps.config, deps.velocityStore));
+
+    let decision: DecisionResponse;
+    let replayed = false;
+    try {
+      if (parsedKey.data === null) {
+        decision = await renderDecision();
+      } else {
+        const result = await deps.idempotencyStore.execute(
+          parsedKey.data,
+          hashTransactionPayload(parsed.data),
+          renderDecision,
+        );
+        decision = result.decision;
+        replayed = result.replayed;
+      }
+    } catch (error) {
+      if (error instanceof IdempotencyConflictError) {
+        deps.metrics.recordRequestFailure("idempotency_conflict");
+        request.log.warn(
+          { event: "idempotency_conflict" },
+          "idempotency key reused with another payload",
+        );
+        return reply.code(409).send({
+          error: "idempotency_conflict",
+          message: "Idempotency-Key est déjà associée à un autre payload",
+        });
+      }
+      if (!(error instanceof StateStoreUnavailableError)) throw error;
+
+      deps.metrics.recordSharedStateFailure();
+      decision = toDecisionResponse(evaluateDegradedRisk(parsed.data, deps.config));
+      reply.header("X-Degraded-Mode", "true");
+      request.log.warn(
+        { event: "shared_state_unavailable", degraded: true },
+        "decision forced to manual review",
+      );
+    }
+
+    if (replayed) {
+      request.log.info(
+        { audit: "decision", decisionId: decision.decisionId, replayed: true },
+        "decision replayed from idempotency cache",
+      );
+      return reply.send(decision);
+    }
+
+    request.log.info(toAuditRecord(decision), "decision rendered");
+    deps.metrics.recordDecision({ decision: decision.decision, degraded: decision.degraded });
+
+    return reply.send(decision);
+  });
+}

--- a/api/src/health.test.ts
+++ b/api/src/health.test.ts
@@ -1,0 +1,64 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { buildApp } from "./app.js";
+import { createReadiness } from "./readiness.js";
+import { testDeps } from "./test-helpers.js";
+
+test("GET /health returns 200 with status ok", async (t) => {
+  const app = buildApp(testDeps());
+  t.after(() => app.close());
+
+  const response = await app.inject({ method: "GET", url: "/health" });
+
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(response.json(), { status: "ok" });
+});
+
+test("GET /ready returns 200 ready by default", async (t) => {
+  const app = buildApp(testDeps());
+  t.after(() => app.close());
+
+  const response = await app.inject({ method: "GET", url: "/ready" });
+
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(response.json(), {
+    status: "ready",
+    mode: "normal",
+    dependencies: { redis: "available" },
+  });
+});
+
+test("GET /ready remains 200 and reports degraded Redis", async (t) => {
+  const app = buildApp(testDeps({ sharedStateStatus: () => "unavailable" }));
+  t.after(() => app.close());
+
+  const response = await app.inject({ method: "GET", url: "/ready" });
+
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(response.json(), {
+    status: "ready",
+    mode: "degraded",
+    dependencies: { redis: "unavailable" },
+  });
+});
+
+test("GET /ready returns 503 once shutdown has begun", async (t) => {
+  const readiness = createReadiness();
+  const app = buildApp(testDeps({ readiness }));
+  t.after(() => app.close());
+
+  readiness.beginShutdown();
+  const response = await app.inject({ method: "GET", url: "/ready" });
+
+  assert.equal(response.statusCode, 503);
+  assert.deepEqual(response.json(), { status: "shutting_down" });
+});
+
+test("every response carries the X-Instance-Id header", async (t) => {
+  const app = buildApp(testDeps());
+  t.after(() => app.close());
+
+  const response = await app.inject({ method: "GET", url: "/health" });
+
+  assert.equal(response.headers["x-instance-id"], "test-instance");
+});

--- a/api/src/metrics.test.ts
+++ b/api/src/metrics.test.ts
@@ -1,0 +1,91 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { buildApp } from "./app.js";
+import { toAuditRecord } from "./decisions.js";
+import type { DecisionResponse } from "./decision.js";
+import type { VelocityStore } from "./velocity-store.js";
+import { postDecision, testDeps } from "./test-helpers.js";
+import { StateStoreUnavailableError } from "./infrastructure/state-store-errors.js";
+
+const validBody = {
+  transactionId: "txn_1",
+  cardId: "card_1",
+  amount: 20,
+  currency: "EUR",
+  country: "FR",
+  channel: "in_store" as const,
+  merchantCategory: "grocery",
+};
+
+test("GET /metrics returns Prometheus text and counts decisions by verdict", async (t) => {
+  const app = buildApp(testDeps());
+  t.after(() => app.close());
+
+  await app.inject(postDecision(validBody));
+  const response = await app.inject({ method: "GET", url: "/metrics" });
+
+  assert.equal(response.statusCode, 200);
+  assert.match(response.headers["content-type"] ?? "", /text\/plain/);
+  assert.match(response.body, /decisions_total\{[^}]*decision="APPROVED"[^}]*\}\s+1/);
+  assert.match(response.body, /http_request_duration_seconds_bucket/);
+});
+
+test("toAuditRecord keeps decision evidence without transaction data", () => {
+  const decision: DecisionResponse = {
+    decisionId: "dec_abc123",
+    decision: "REVIEW",
+    score: 30,
+    reasons: [
+      {
+        rule: "COUNTRY_RISK",
+        weight: 25,
+        detail: "transaction country is outside the configured allowlist",
+      },
+    ],
+    evaluatedAt: "2026-08-29T12:00:00.000Z",
+    degraded: false,
+  };
+  const record = toAuditRecord(decision);
+
+  assert.equal(record.audit, "decision");
+  assert.equal(record.decisionId, "dec_abc123");
+  assert.equal(record.decision, "REVIEW");
+  assert.deepEqual(record.reasons, ["COUNTRY_RISK"]);
+  for (const field of [
+    "transactionId",
+    "cardId",
+    "amount",
+    "currency",
+    "country",
+    "channel",
+    "merchantCategory",
+  ]) {
+    assert.equal(field in record, false, `${field} ne doit pas être journalisé`);
+  }
+});
+
+test("degraded decisions and shared state failures have dedicated metrics", async (t) => {
+  const unavailableStore: VelocityStore = {
+    hit: () => Promise.reject(new StateStoreUnavailableError("Redis unavailable")),
+  };
+  const deps = testDeps({ velocityStore: unavailableStore });
+  const app = buildApp(deps);
+  t.after(() => app.close());
+
+  await app.inject(postDecision(validBody));
+  deps.metrics.recordCircuitTransition({ from: "CLOSED", to: "OPEN" });
+  deps.metrics.recordAuthFailure();
+  deps.metrics.recordRequestFailure("invalid_request_id");
+  deps.metrics.recordRequestAborted("timeout");
+  deps.metrics.recordRateLimitFallback();
+  const body = await deps.metrics.registry.metrics();
+
+  assert.match(body, /degraded_decisions_total 1/);
+  assert.match(body, /shared_state_errors_total 1/);
+  assert.match(body, /redis_circuit_transitions_total\{from="CLOSED",to="OPEN"\} 1/);
+  assert.match(body, /authentication_failures_total 1/);
+  assert.match(body, /request_failures_total\{code="invalid_request_id"\} 1/);
+  assert.match(body, /http_requests_aborted_total\{reason="timeout"\} 1/);
+  assert.match(body, /rate_limit_fallback_total 1/);
+  assert.match(body, /http_requests_in_flight 0/);
+});

--- a/api/src/metrics.ts
+++ b/api/src/metrics.ts
@@ -1,0 +1,144 @@
+import { Counter, Gauge, Histogram, Registry } from "prom-client";
+
+export type HttpSample = {
+  method: string;
+  route: string;
+  statusCode: number;
+  durationSeconds: number;
+};
+
+export type Metrics = {
+  registry: Registry;
+  recordHttpRequest(sample: HttpSample): void;
+  recordDecision(sample: { decision: string; degraded: boolean }): void;
+  recordSharedStateFailure(): void;
+  recordCircuitTransition(sample: { from: string; to: string }): void;
+  recordAuthFailure(): void;
+  recordRateLimitExceeded(profile: "public" | "load"): void;
+  recordRateLimitFallback(): void;
+  recordRequestFailure(code: string): void;
+  requestStarted(): void;
+  requestFinished(): void;
+  recordRequestAborted(reason: "aborted" | "timeout"): void;
+};
+
+/**
+ * Fabrique un registre Prometheus neuf avec les métriques de l'application.
+ * Un registre par appel (pas le registre global) : aucune collision entre
+ * instances, notamment dans les tests. Les métriques process par défaut
+ * (`collectDefaultMetrics`) sont branchées à part, dans `server.ts`.
+ */
+export function createMetrics(): Metrics {
+  const registry = new Registry();
+
+  const httpDuration = new Histogram({
+    name: "http_request_duration_seconds",
+    help: "Durée des requêtes HTTP, par route et code de statut",
+    labelNames: ["method", "route", "status_code"],
+    buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5],
+    registers: [registry],
+  });
+
+  const decisionsTotal = new Counter({
+    name: "decisions_total",
+    help: "Décisions rendues, par verdict et état de dégradation",
+    labelNames: ["decision", "degraded"],
+    registers: [registry],
+  });
+
+  const degradedDecisionsTotal = new Counter({
+    name: "degraded_decisions_total",
+    help: "Décisions forcées en revue car l'état partagé est indisponible",
+    registers: [registry],
+  });
+
+  const sharedStateErrorsTotal = new Counter({
+    name: "shared_state_errors_total",
+    help: "Opérations d'état partagé ayant déclenché le mode fail-safe",
+    registers: [registry],
+  });
+
+  const circuitTransitionsTotal = new Counter({
+    name: "redis_circuit_transitions_total",
+    help: "Transitions du circuit breaker Redis",
+    labelNames: ["from", "to"],
+    registers: [registry],
+  });
+
+  const authFailuresTotal = new Counter({
+    name: "authentication_failures_total",
+    help: "Requêtes métier rejetées pour authentification absente ou invalide",
+    registers: [registry],
+  });
+
+  const rateLimitExceededTotal = new Counter({
+    name: "rate_limit_exceeded_total",
+    help: "Requêtes refusées par le rate limiting",
+    labelNames: ["profile"],
+    registers: [registry],
+  });
+
+  const rateLimitFallbackTotal = new Counter({
+    name: "rate_limit_fallback_total",
+    help: "Comptages servis par la protection locale pendant une panne Redis",
+    registers: [registry],
+  });
+
+  const requestFailuresTotal = new Counter({
+    name: "request_failures_total",
+    help: "Requêtes refusées ou échouées par code stable",
+    labelNames: ["code"],
+    registers: [registry],
+  });
+
+  const inFlightRequests = new Gauge({
+    name: "http_requests_in_flight",
+    help: "Nombre de requêtes HTTP en cours dans cette instance",
+    registers: [registry],
+  });
+
+  const requestAbortedTotal = new Counter({
+    name: "http_requests_aborted_total",
+    help: "Connexions abandonnées ou expirées",
+    labelNames: ["reason"],
+    registers: [registry],
+  });
+
+  return {
+    registry,
+    recordHttpRequest({ method, route, statusCode, durationSeconds }) {
+      httpDuration.observe({ method, route, status_code: String(statusCode) }, durationSeconds);
+    },
+    recordDecision({ decision, degraded }) {
+      decisionsTotal.inc({ decision, degraded: String(degraded) });
+      if (degraded) degradedDecisionsTotal.inc();
+    },
+    recordSharedStateFailure() {
+      sharedStateErrorsTotal.inc();
+    },
+    recordCircuitTransition({ from, to }) {
+      circuitTransitionsTotal.inc({ from, to });
+    },
+    recordAuthFailure() {
+      authFailuresTotal.inc();
+    },
+    recordRateLimitExceeded(profile) {
+      rateLimitExceededTotal.inc({ profile });
+    },
+    recordRateLimitFallback() {
+      rateLimitFallbackTotal.inc();
+    },
+    recordRequestFailure(code) {
+      requestFailuresTotal.inc({ code });
+    },
+    requestStarted() {
+      inFlightRequests.inc();
+    },
+    requestFinished() {
+      inFlightRequests.dec();
+    },
+    recordRequestAborted(reason) {
+      requestAbortedTotal.inc({ reason });
+    },
+  };
+}

--- a/api/src/observability.test.ts
+++ b/api/src/observability.test.ts
@@ -1,0 +1,48 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type { DestinationStream } from "pino";
+import { createAppLogger } from "./observability.js";
+import { testConfig } from "./test-helpers.js";
+
+test("structured logger redacts secrets, identifiers and payloads", () => {
+  const chunks: string[] = [];
+  const destination: DestinationStream = {
+    write(chunk) {
+      chunks.push(String(chunk));
+    },
+  };
+  const logger = createAppLogger(
+    { ...testConfig, logLevel: "info" },
+    "instance-redaction",
+    destination,
+  );
+
+  logger.info({
+    event: "redaction_test",
+    headers: {
+      "x-api-key": "api-secret-never-visible",
+      "idempotency-key": "idempotency-secret-never-visible",
+    },
+    context: {
+      cardId: "card-never-visible",
+      transactionId: "transaction-never-visible",
+      payload: { amount: 999 },
+    },
+  });
+
+  const output = chunks.join("");
+  for (const sensitive of [
+    "api-secret-never-visible",
+    "idempotency-secret-never-visible",
+    "card-never-visible",
+    "transaction-never-visible",
+    '"amount":999',
+  ]) {
+    assert.doesNotMatch(output, new RegExp(sensitive));
+  }
+  assert.match(output, /\[REDACTED\]/);
+  assert.match(output, /"service":"transaction-risk-gate-api"/);
+  assert.match(output, /"environment":"local"/);
+  assert.match(output, /"version":"test"/);
+  assert.match(output, /"instanceId":"instance-redaction"/);
+});

--- a/api/src/observability.ts
+++ b/api/src/observability.ts
@@ -1,0 +1,53 @@
+import pino, { type DestinationStream, type Logger, type LoggerOptions } from "pino";
+import type { Config } from "./config.js";
+
+export const REDACTED_LOG_PATHS = Object.freeze([
+  "headers",
+  "req.headers",
+  "request.headers",
+  "body",
+  "payload",
+  "transaction",
+  "cardId",
+  "transactionId",
+  "idempotencyKey",
+  "apiKey",
+  "redisHmacSecret",
+  "loadTestToken",
+  "*.headers",
+  "*.body",
+  "*.payload",
+  "*.transaction",
+  "*.cardId",
+  "*.transactionId",
+  "*.idempotencyKey",
+  "*.apiKey",
+  "*.redisHmacSecret",
+  "*.loadTestToken",
+]);
+
+export function createLoggerOptions(config: Config, instanceId: string): LoggerOptions {
+  return {
+    level: config.logLevel,
+    base: {
+      service: "transaction-risk-gate-api",
+      environment: config.appEnvironment,
+      version: config.appVersion,
+      instanceId,
+    },
+    timestamp: pino.stdTimeFunctions.isoTime,
+    redact: {
+      paths: [...REDACTED_LOG_PATHS],
+      censor: "[REDACTED]",
+    },
+  };
+}
+
+export function createAppLogger(
+  config: Config,
+  instanceId: string,
+  destination?: DestinationStream,
+): Logger {
+  const options = createLoggerOptions(config, instanceId);
+  return destination === undefined ? pino(options) : pino(options, destination);
+}

--- a/api/src/readiness.test.ts
+++ b/api/src/readiness.test.ts
@@ -1,0 +1,15 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createReadiness } from "./readiness.js";
+
+test("starts ready", () => {
+  assert.equal(createReadiness().isReady(), true);
+});
+
+test("beginShutdown flips it to not ready, and stays there", () => {
+  const readiness = createReadiness();
+  readiness.beginShutdown();
+  assert.equal(readiness.isReady(), false);
+  readiness.beginShutdown();
+  assert.equal(readiness.isReady(), false);
+});

--- a/api/src/readiness.ts
+++ b/api/src/readiness.ts
@@ -1,0 +1,19 @@
+/**
+ * État « puis-je servir du trafic ? », lu par `GET /ready` et basculé par
+ * l'arrêt gracieux. Un petit objet injecté dans `deps` — pas d'état global
+ * mutable.
+ */
+export type Readiness = {
+  isReady(): boolean;
+  beginShutdown(): void;
+};
+
+export function createReadiness(): Readiness {
+  let ready = true;
+  return {
+    isReady: () => ready,
+    beginShutdown: () => {
+      ready = false;
+    },
+  };
+}

--- a/api/src/security-boundaries.test.ts
+++ b/api/src/security-boundaries.test.ts
@@ -1,0 +1,144 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { buildApp, rateLimitProfile } from "./app.js";
+import { postDecision, TEST_API_KEY, testConfig, testDeps } from "./test-helpers.js";
+
+const validBody = {
+  transactionId: "txn_security_1",
+  cardId: "card_security_1",
+  amount: 20,
+  currency: "EUR",
+  country: "FR",
+  channel: "in_store",
+  merchantCategory: "grocery",
+};
+
+const authGet = (url: string, headers: Record<string, string> = {}) => ({
+  method: "GET" as const,
+  url,
+  headers: { "x-api-key": TEST_API_KEY, ...headers },
+});
+
+test("safe X-Request-Id is echoed and an unsafe value is rejected", async (t) => {
+  const app = buildApp(testDeps());
+  t.after(() => app.close());
+
+  const safe = await app.inject(authGet("/api/rules", { "x-request-id": "req.safe-123" }));
+  assert.equal(safe.statusCode, 200);
+  assert.equal(safe.headers["x-request-id"], "req.safe-123");
+
+  const unsafe = await app.inject(authGet("/api/rules", { "x-request-id": "bad value\nline" }));
+  assert.equal(unsafe.statusCode, 400);
+  assert.equal(unsafe.json().error, "invalid_request_id");
+  assert.notEqual(unsafe.headers["x-request-id"], "bad value\nline");
+});
+
+test("unexpected query parameters and oversized payloads are rejected", async (t) => {
+  const deps = testDeps({ config: { ...testConfig, bodyLimitBytes: 1_024 } });
+  const app = buildApp(deps);
+  t.after(() => app.close());
+
+  const query = await app.inject(authGet("/api/rules?unexpected=true"));
+  assert.equal(query.statusCode, 400);
+  assert.equal(query.json().error, "unexpected_query");
+
+  const oversized = await app.inject(postDecision({ ...validBody, cardId: "x".repeat(2_000) }));
+  assert.equal(oversized.statusCode, 413);
+  assert.equal(oversized.json().error, "payload_too_large");
+});
+
+test("malformed JSON and unsupported media types keep precise client status codes", async (t) => {
+  const app = buildApp(testDeps());
+  t.after(() => app.close());
+
+  const malformed = await app.inject({
+    method: "POST",
+    url: "/api/decisions",
+    headers: { "content-type": "application/json", "x-api-key": TEST_API_KEY },
+    payload: '{"transactionId":',
+  });
+  assert.equal(malformed.statusCode, 400);
+  assert.equal(malformed.json().error, "invalid_request");
+
+  const unsupported = await app.inject({
+    method: "POST",
+    url: "/api/decisions",
+    headers: { "content-type": "text/plain", "x-api-key": TEST_API_KEY },
+    payload: "not-json",
+  });
+  assert.equal(unsupported.statusCode, 415);
+  assert.equal(unsupported.json().error, "unsupported_media_type");
+});
+
+test("every response carries defensive security headers", async (t) => {
+  const app = buildApp(testDeps());
+  t.after(() => app.close());
+
+  const response = await app.inject({ method: "GET", url: "/health" });
+  assert.equal(response.headers["cache-control"], "no-store");
+  assert.equal(response.headers["x-content-type-options"], "nosniff");
+  assert.equal(response.headers["x-frame-options"], "DENY");
+  assert.equal(response.headers["referrer-policy"], "no-referrer");
+  assert.match(response.headers["content-security-policy"] ?? "", /default-src 'none'/);
+});
+
+test("public API profile is blocked after its configured ceiling", async (t) => {
+  const deps = testDeps({
+    config: {
+      ...testConfig,
+      rateLimitMax: 2,
+      rateLimitLoadMax: 4,
+      rateLimitWindowMs: 60_000,
+    },
+  });
+  const app = buildApp(deps);
+  t.after(() => app.close());
+
+  assert.equal((await app.inject(authGet("/api/rules"))).statusCode, 200);
+  assert.equal((await app.inject(authGet("/api/rules"))).statusCode, 200);
+  const limited = await app.inject(authGet("/api/rules"));
+  assert.equal(limited.statusCode, 429);
+  assert.equal(limited.json().error, "rate_limit_exceeded");
+
+  const metrics = await deps.metrics.registry.metrics();
+  assert.match(metrics, /rate_limit_exceeded_total\{profile="public"\} 1/);
+});
+
+test("a valid load token raises the ceiling only outside production", async (t) => {
+  const loadTestToken = "load-test-token-with-at-least-32-bytes";
+  const deps = testDeps({
+    config: {
+      ...testConfig,
+      appEnvironment: "integration",
+      loadTestToken,
+      rateLimitMax: 1,
+      rateLimitLoadMax: 3,
+      rateLimitWindowMs: 60_000,
+    },
+  });
+  const app = buildApp(deps);
+  t.after(() => app.close());
+  const loadHeaders = { "x-load-test-token": loadTestToken };
+
+  assert.equal((await app.inject(authGet("/api/rules", loadHeaders))).statusCode, 200);
+  assert.equal((await app.inject(authGet("/api/rules", loadHeaders))).statusCode, 200);
+  assert.equal((await app.inject(authGet("/api/rules", loadHeaders))).statusCode, 200);
+  assert.equal((await app.inject(authGet("/api/rules", loadHeaders))).statusCode, 429);
+
+  assert.equal(
+    rateLimitProfile(
+      { "x-load-test-token": loadTestToken },
+      { ...deps.config, appEnvironment: "production" },
+    ),
+    "public",
+  );
+});
+
+test("malformed load token is rejected before business processing", async (t) => {
+  const app = buildApp(testDeps());
+  t.after(() => app.close());
+
+  const response = await app.inject(authGet("/api/rules", { "x-load-test-token": "short" }));
+  assert.equal(response.statusCode, 400);
+  assert.equal(response.json().error, "invalid_load_test_token");
+});

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -1,0 +1,110 @@
+import { hostname } from "node:os";
+import { z } from "zod";
+import { collectDefaultMetrics } from "prom-client";
+import { buildApp } from "./app.js";
+import { loadConfig, type Config } from "./config.js";
+import { createMetrics } from "./metrics.js";
+import { createReadiness } from "./readiness.js";
+import { registerGracefulShutdown } from "./shutdown.js";
+import { RedisStateStore } from "./infrastructure/redis-state-store.js";
+import type { CircuitState } from "./infrastructure/circuit-breaker.js";
+import { createRateLimitStore } from "./rate-limit-store.js";
+
+// Fail fast : une configuration invalide arrête le process avant tout démarrage
+// de serveur, avec la liste lisible des variables fautives.
+let config: Config;
+try {
+  config = loadConfig();
+} catch (error) {
+  if (error instanceof z.ZodError) {
+    console.error(`Configuration invalide :\n${z.prettifyError(error)}`);
+  } else {
+    console.error(error);
+  }
+  process.exit(1);
+}
+
+const metrics = createMetrics();
+// Métriques process (heap, GC, event-loop lag) : ici, pas dans createMetrics(),
+// pour ne pas poser de timer dans les tests.
+collectDefaultMetrics({ register: metrics.registry });
+
+const readiness = createReadiness();
+
+let reportCircuitTransition = (_from: CircuitState, _to: CircuitState) => {};
+let reportRedisError = (_error: Error) => {};
+let reportAvailability = (_from: string, _to: string) => {};
+const stateStore = new RedisStateStore({
+  url: config.redisUrl,
+  hmacSecret: config.redisHmacSecret,
+  velocityWindowSeconds: config.velocityWindowSeconds,
+  commandTimeoutMs: config.redisCommandTimeoutMs,
+  circuitFailureThreshold: config.redisCircuitFailureThreshold,
+  circuitResetMs: config.redisCircuitResetMs,
+  idempotencyTtlSeconds: config.idempotencyTtlSeconds,
+  idempotencyLockMs: config.idempotencyLockMs,
+  idempotencyWaitMs: config.idempotencyWaitMs,
+  onCircuitTransition: (from, to) => reportCircuitTransition(from, to),
+  onAvailabilityChange: (from, to) => reportAvailability(from, to),
+  onClientError: (error) => reportRedisError(error),
+});
+const rateLimitStore = createRateLimitStore(stateStore, () => metrics.recordRateLimitFallback());
+
+const app = buildApp({
+  config,
+  velocityStore: stateStore,
+  idempotencyStore: stateStore,
+  metrics,
+  readiness,
+  // En conteneur, le nom d'hôte est l'identifiant du conteneur.
+  instanceId: process.env.INSTANCE_ID ?? hostname(),
+  sharedStateStatus: () => stateStore.availability,
+  rateLimitStore,
+});
+
+reportCircuitTransition = (from, to) => {
+  const level = to === "CLOSED" ? "info" : "warn";
+  metrics.recordCircuitTransition({ from, to });
+  app.log[level]({ event: "redis_circuit_transition", from, to }, "Redis circuit changed state");
+};
+reportRedisError = (error) => {
+  app.log.error({ event: "redis_client_error", errorType: error.name }, "Redis client error");
+};
+reportAvailability = (from, to) => {
+  const event = to === "available" ? "redis_recovered" : "redis_unavailable";
+  const level = to === "available" ? "info" : "warn";
+  app.log[level]({ event, from, to }, "Redis availability changed");
+};
+app.addHook("onClose", async () => stateStore.close());
+
+try {
+  try {
+    await stateStore.probe();
+  } catch (error) {
+    app.log.warn(
+      {
+        event: "redis_initial_probe_failed",
+        errorType: error instanceof Error ? error.name : "UnknownError",
+      },
+      "Redis initial probe failed; starting in degraded mode",
+    );
+  }
+
+  const address = await app.listen({ host: config.host, port: config.port });
+  app.log.info({ event: "server_listening", address }, "server listening");
+
+  // Le canal IPC permet aux tests d'intégration et aux superviseurs de
+  // détecter la disponibilité sans dépendre du format humain des logs.
+  process.send?.({ event: "server_listening", address });
+} catch (error) {
+  app.log.error(error);
+  process.exit(1);
+}
+
+// SIGTERM / SIGINT : /ready passe à 503, on laisse le load balancer nous retirer,
+// puis on draine les requêtes en cours et on sort.
+registerGracefulShutdown(app, {
+  timeoutMs: config.shutdownTimeoutMs,
+  drainDelayMs: config.shutdownDelayMs,
+  onShutdownStart: () => readiness.beginShutdown(),
+});

--- a/api/src/shutdown.integration.test.ts
+++ b/api/src/shutdown.integration.test.ts
@@ -1,0 +1,132 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawn, type ChildProcess } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { once } from "node:events";
+import { createServer } from "node:net";
+
+// SIGTERM n'est pas émulé sur Windows (process.kill le transforme en arrêt
+// brutal). Ce test tourne en CI et dans le conteneur, où l'arrêt gracieux compte.
+const skip = process.platform === "win32" ? "SIGTERM non émulé sur Windows" : false;
+
+const childEnv = {
+  ...process.env,
+  API_KEY: randomBytes(32).toString("hex"),
+  REDIS_URL: "redis://127.0.0.1:6379",
+  REDIS_HMAC_SECRET: randomBytes(32).toString("hex"),
+  AMOUNT_THRESHOLD: "1000",
+  VELOCITY_MAX: "3",
+  VELOCITY_WINDOW_SECONDS: "60",
+  ALLOWED_COUNTRIES: "FR",
+  HIGH_RISK_MERCHANT_CATEGORIES: "crypto",
+  HOST: "127.0.0.1",
+  LOG_LEVEL: "info",
+  SHUTDOWN_DELAY_MS: "1000", // fenêtre où /ready doit déjà renvoyer 503
+};
+
+const findAvailablePort = async (): Promise<number> => {
+  const probe = createServer();
+  await new Promise<void>((resolve, reject) => {
+    probe.once("error", reject);
+    probe.listen(0, "127.0.0.1", resolve);
+  });
+
+  const address = probe.address();
+  await new Promise<void>((resolve, reject) => {
+    probe.close((error) => (error ? reject(error) : resolve()));
+  });
+
+  if (address === null || typeof address === "string") {
+    throw new Error("port local temporaire introuvable");
+  }
+  return address.port;
+};
+
+const waitForServerAddress = (child: ChildProcess, readStderr: () => string): Promise<string> =>
+  new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject(new Error(`le serveur enfant n'est pas prêt après 10 s\n${readStderr()}`));
+    }, 10_000);
+
+    const cleanup = () => {
+      clearTimeout(timeout);
+      child.off("message", onMessage);
+      child.off("error", onError);
+      child.off("exit", onExit);
+    };
+
+    const onMessage = (message: unknown) => {
+      if (
+        typeof message === "object" &&
+        message !== null &&
+        "event" in message &&
+        message.event === "server_listening" &&
+        "address" in message &&
+        typeof message.address === "string"
+      ) {
+        cleanup();
+        resolve(message.address);
+      }
+    };
+
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      cleanup();
+      reject(
+        new Error(
+          `le serveur enfant s'est arrêté avant readiness (code=${code}, signal=${signal})\n${readStderr()}`,
+        ),
+      );
+    };
+
+    child.on("message", onMessage);
+    child.once("error", onError);
+    child.once("exit", onExit);
+  });
+
+test(
+  "SIGTERM: /ready passe à 503 pendant le drain, puis le serveur sort en 0",
+  { skip },
+  async (context) => {
+    const port = await findAvailablePort();
+    const child = spawn(process.execPath, ["--import", "tsx", "src/server.ts"], {
+      env: { ...childEnv, PORT: String(port) },
+      stdio: ["ignore", "ignore", "pipe", "ipc"],
+    });
+
+    let stderr = "";
+    child.stderr?.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+    context.after(() => {
+      if (child.exitCode === null && child.signalCode === null) {
+        child.kill("SIGKILL");
+      }
+    });
+
+    const address = await waitForServerAddress(child, () => stderr);
+    assert.equal(
+      Number(new URL(address).port),
+      port,
+      `adresse inattendue du serveur enfant : ${address}`,
+    );
+
+    const before = await fetch(`http://127.0.0.1:${port}/ready`);
+    assert.equal(before.status, 200);
+
+    const exitPromise = once(child, "exit");
+    child.kill("SIGTERM");
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    const during = await fetch(`http://127.0.0.1:${port}/ready`);
+    assert.equal(during.status, 503);
+
+    const [code] = await exitPromise;
+    assert.equal(code, 0);
+  },
+);

--- a/api/src/shutdown.test.ts
+++ b/api/src/shutdown.test.ts
@@ -1,0 +1,49 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { shutdownGracefully } from "./shutdown.js";
+
+const silentLog = { info() {}, error() {} };
+
+function fakeApp(close: () => Promise<void>) {
+  return { close, log: silentLog } as unknown as Parameters<typeof shutdownGracefully>[0];
+}
+
+test("resolves once app.close() completes", async () => {
+  let closed = false;
+  await shutdownGracefully(
+    fakeApp(async () => {
+      await new Promise((r) => setTimeout(r, 5));
+      closed = true;
+    }),
+    1000,
+  );
+  assert.equal(closed, true);
+});
+
+test("rejects when draining exceeds the timeout", async () => {
+  let release!: () => void;
+  const slowClose = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+
+  await assert.rejects(
+    shutdownGracefully(
+      fakeApp(() => slowClose),
+      20,
+    ),
+    /drainage non terminé en 20 ms/,
+  );
+
+  release(); // libère la promesse pour ne pas la laisser pendante
+  await slowClose;
+});
+
+test("propagates an error from app.close()", async () => {
+  await assert.rejects(
+    shutdownGracefully(
+      fakeApp(() => Promise.reject(new Error("close a échoué"))),
+      1000,
+    ),
+    /close a échoué/,
+  );
+});

--- a/api/src/shutdown.ts
+++ b/api/src/shutdown.ts
@@ -1,0 +1,79 @@
+import type { FastifyInstance } from "fastify";
+
+type Closable = Pick<FastifyInstance, "close" | "log">;
+
+/**
+ * Attend la fin du drainage (`app.close()` : plus de nouvelles connexions, les
+ * requêtes en cours se terminent), avec un plafond de temps. Rejette si le
+ * drainage dépasse `timeoutMs` ou si `close()` échoue. Ne touche pas au process.
+ */
+export function shutdownGracefully(app: Closable, timeoutMs: number): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    // Pas de `unref()` : pendant le drainage, on veut justement que ce timer
+    // maintienne le process en vie jusqu'à `close()` ou l'échéance.
+    const timer = setTimeout(
+      () => reject(new Error(`drainage non terminé en ${timeoutMs} ms`)),
+      timeoutMs,
+    );
+
+    app.close().then(
+      () => {
+        clearTimeout(timer);
+        resolve();
+      },
+      (error: unknown) => {
+        clearTimeout(timer);
+        reject(
+          error instanceof Error ? error : new Error("app.close() a échoué", { cause: error }),
+        );
+      },
+    );
+  });
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+export type ShutdownOptions = {
+  timeoutMs: number;
+  /** Délai entre « /ready → 503 » et l'arrêt des connexions, le temps que le
+   *  load balancer nous retire du pool. `0` pour désactiver. */
+  drainDelayMs: number;
+  /** Appelé dès le signal, avant le délai — typiquement `readiness.beginShutdown`. */
+  onShutdownStart?: () => void;
+};
+
+/**
+ * Branche SIGTERM (plateforme) et SIGINT (Ctrl+C) sur un arrêt gracieux :
+ * signal → `onShutdownStart` → délai de drain → `app.close()` → exit.
+ * Premier signal seulement ; un second est ignoré, l'arrêt est déjà lancé.
+ */
+export function registerGracefulShutdown(app: FastifyInstance, options: ShutdownOptions): void {
+  let started = false;
+
+  const handle = async (signal: NodeJS.Signals): Promise<void> => {
+    if (started) return;
+    started = true;
+    app.log.info(
+      { event: "shutdown_started", signal },
+      "arrêt gracieux : /ready renvoie désormais 503",
+    );
+    options.onShutdownStart?.();
+
+    if (options.drainDelayMs > 0) await sleep(options.drainDelayMs);
+
+    try {
+      await shutdownGracefully(app, options.timeoutMs);
+      app.log.info({ event: "shutdown_completed" }, "arrêt gracieux terminé");
+      process.exit(0);
+    } catch (error) {
+      app.log.error(
+        { event: "shutdown_failed", errorType: error instanceof Error ? error.name : "unknown" },
+        "arrêt gracieux : échec ou dépassement, sortie forcée",
+      );
+      process.exit(1);
+    }
+  };
+
+  process.once("SIGTERM", (signal) => void handle(signal));
+  process.once("SIGINT", (signal) => void handle(signal));
+}

--- a/api/src/test-helpers.ts
+++ b/api/src/test-helpers.ts
@@ -1,0 +1,67 @@
+import { randomBytes } from "node:crypto";
+import type { AppDeps } from "./app.js";
+import type { Config } from "./config.js";
+import { InMemoryVelocityStore } from "./velocity-store.js";
+import { InMemoryIdempotencyStore } from "./idempotency-store.js";
+import { createMetrics } from "./metrics.js";
+import { createReadiness } from "./readiness.js";
+
+const createTestSecret = (): string => randomBytes(32).toString("hex");
+
+export const TEST_API_KEY = createTestSecret();
+
+export const testConfig: Config = Object.freeze({
+  host: "0.0.0.0",
+  port: 3000,
+  appEnvironment: "local",
+  appVersion: "test",
+  logLevel: "silent",
+  bodyLimitBytes: 16_384,
+  connectionTimeoutMs: 10_000,
+  requestTimeoutMs: 15_000,
+  keepAliveTimeoutMs: 5_000,
+  maxRequestsPerSocket: 1_000,
+  trustProxyHops: 0,
+  rateLimitMax: 60,
+  rateLimitLoadMax: 5_000,
+  rateLimitWindowMs: 60_000,
+  loadTestToken: undefined,
+  shutdownTimeoutMs: 10_000,
+  shutdownDelayMs: 0,
+  apiKey: TEST_API_KEY,
+  redisUrl: "redis://127.0.0.1:6379",
+  redisHmacSecret: createTestSecret(),
+  redisCommandTimeoutMs: 250,
+  redisCircuitFailureThreshold: 3,
+  redisCircuitResetMs: 10_000,
+  idempotencyTtlSeconds: 86_400,
+  idempotencyLockMs: 5_000,
+  idempotencyWaitMs: 2_000,
+  amountThreshold: 1000,
+  velocityMax: 3,
+  velocityWindowSeconds: 60,
+  allowedCountries: ["FR", "DE"],
+  highRiskMerchantCategories: ["gambling", "crypto"],
+});
+
+export function testDeps(overrides: Partial<AppDeps> = {}): AppDeps {
+  return {
+    config: testConfig,
+    velocityStore: new InMemoryVelocityStore(60, () => 0),
+    idempotencyStore: new InMemoryIdempotencyStore(),
+    metrics: createMetrics(),
+    readiness: createReadiness(),
+    instanceId: "test-instance",
+    ...overrides,
+  };
+}
+
+/** Options `app.inject` d'un POST /api/decisions, clé d'API incluse par défaut. */
+export function postDecision(body: unknown, headers: Record<string, string> = {}) {
+  return {
+    method: "POST" as const,
+    url: "/api/decisions",
+    payload: JSON.stringify(body),
+    headers: { "content-type": "application/json", "x-api-key": TEST_API_KEY, ...headers },
+  };
+}


### PR DESCRIPTION
## Résultat attendu

Un contrat API minimal, sécurisé et observable de bout en bout : `POST /api/decisions`,
`GET /api/rules`, `GET /health`, `GET /ready`, `GET /metrics` ; validation stricte des en-têtes,
paramètres et corps ; clé de service `X-API-Key` sur `/api/*` (sondes laissées ouvertes) ;
rate limiting ; logs JSON structurés avec redaction ; readiness et arrêt gracieux avec drainage.

## Travail et périmètre

- Issue : `TRG-4` / #13
- Branche source : `security/TRG-4-api-observable` → `develop`
- Labels : `type:security`, `risk:high`, `area:api`, `area:quality`, `release:required`
- Inclus : `app.ts` (composition Fastify), `auth.ts` (comparaison temps constant), `decisions.ts`
  (routes + validation zod), `metrics.ts` (Prometheus), `observability.ts` (pino + `reqId` +
  redaction `cardId`/secrets/payload), `readiness.ts`, `shutdown.ts` (SIGTERM + drainage), `server.ts`.
- Exclu : interface web, conteneurs, déploiement — tranches suivantes.

## Risques et compatibilité

- Niveau de risque : high — surface HTTP publique de l'API et frontières de sécurité.
- Impact sécurité : `X-API-Key` requis sur `/api/*` ; `/health`, `/ready`, `/metrics` **ouverts**
  (les sondes Azure Container Apps n'envoient pas d'en-tête personnalisé).
- Rollback : `develop` reste vert sans cette PR.

## Vérification

- `npm run test:coverage --prefix api` : **99 tests** (98 passés, 1 sauté = intégration SIGTERM
  non émulée sous Windows, exécutée en CI Linux), **95,3 % lignes**.
- Redaction testée : aucun `cardId`, secret, payload complet ni clé d'idempotence journalisé.
- Frontières testées (`security-boundaries.test.ts`) : `401` sans clé, sondes accessibles sans clé.
- `prettier`, `markdownlint`, `validate-repository`, `pre-commit`, `pre-push` : verts.

## Notes pour le reviewer

La clé de service ne quitte jamais le serveur : le web public l'injecte vers l'API privée (TRG-5 /
TRG-7). `evaluate()` reste déterministe ; le seul effet de bord assumé est l'incrément de vélocité.

Closes #13
