### PR TITLE
[TRG-5] construire le simulateur web

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,10 +93,14 @@ jobs:
         with:
           node-version: 24
           cache: npm
-          cache-dependency-path: api/package-lock.json
+          cache-dependency-path: |
+            api/package-lock.json
+            web/package-lock.json
 
-      - name: Installer les dépendances de l’API
-        run: npm ci --prefix api
+      - name: Installer les dépendances
+        run: |
+          npm ci --prefix api
+          npm ci --prefix web
 
       - name: Compiler l’API en TypeScript strict
         run: npm run build --prefix api
@@ -107,6 +111,9 @@ jobs:
       - name: Vérifier la cible renforcée du domaine à 90 %
         run: npm run test:coverage:domain --prefix api
 
+      - name: Tester et couvrir le web à 80 % minimum
+        run: npm run test:coverage --prefix web
+
       - name: Publier les rapports LCOV
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -114,5 +121,7 @@ jobs:
           path: |
             api/coverage/lcov.info
             api/coverage/coverage-summary.json
+            web/coverage/lcov.info
+            web/coverage/coverage-summary.json
           if-no-files-found: error
           retention-days: 7

--- a/web/app.mjs
+++ b/web/app.mjs
@@ -1,0 +1,246 @@
+import { createReplicaTracker } from "./replica-tracker.mjs";
+import {
+  SCENARIOS,
+  createSessionHistory,
+  newIdempotencyKey,
+  newTransactionId,
+  submitTransaction,
+  validateTransactionDraft,
+} from "./transaction-simulator.mjs";
+
+const STATUS_POLL_MS = 5_000;
+const tracker = createReplicaTracker();
+const history = createSessionHistory(20);
+const el = (id) => document.getElementById(id);
+const form = el("transaction-form");
+
+const decisionMessages = {
+  APPROVED: "La transaction ne franchit aucun seuil nécessitant une action supplémentaire.",
+  REVIEW: "Un contrôle humain ou un signal complémentaire est nécessaire avant décision finale.",
+  REJECTED: "Le cumul des signaux atteint le seuil de rejet de cette politique heuristique.",
+};
+
+async function fetchJSON(path) {
+  const response = await fetch(path, { headers: { accept: "application/json" } });
+  tracker.observe(response.headers.get("x-instance-id"));
+  updateReplicaCount();
+  if (!response.ok) throw new Error(`${response.status}`);
+  return { payload: await response.json(), response };
+}
+
+function textCell(row, value, className) {
+  const cell = document.createElement("td");
+  cell.textContent = value;
+  if (className) cell.className = className;
+  row.append(cell);
+  return cell;
+}
+
+function updateReplicaCount() {
+  el("replica-count").textContent = String(tracker.count());
+}
+
+function setServiceStatus(mode, label) {
+  const status = el("status");
+  status.className = `status status-${mode}`;
+  el("status-label").textContent = label;
+}
+
+async function refreshServiceStatus() {
+  try {
+    const { payload } = await fetchJSON("/ready");
+    if (payload.mode === "degraded") {
+      setServiceStatus("degraded", "Service dégradé · revue forcée");
+    } else {
+      setServiceStatus("normal", "Service opérationnel");
+    }
+  } catch {
+    setServiceStatus("offline", "API indisponible");
+  }
+  updateReplicaCount();
+}
+
+function formatParameters(parameters) {
+  return Object.entries(parameters)
+    .map(([key, value]) => `${key} = ${Array.isArray(value) ? value.join(", ") : value}`)
+    .join(" · ");
+}
+
+async function loadRules() {
+  try {
+    const { payload: view } = await fetchJSON("/api/rules");
+    el("score-bands").textContent =
+      `APPROVED 0–${view.scoreBands.approved.max} · ` +
+      `REVIEW ${view.scoreBands.review.min}–${view.scoreBands.review.max} · ` +
+      `REJECTED ${view.scoreBands.rejected.min}–${view.scoreBands.rejected.max}`;
+    const rows = view.rules.map((rule) => {
+      const row = document.createElement("tr");
+      textCell(row, rule.rule, "rule-name");
+      textCell(row, `+${rule.weight}`, "weight");
+      textCell(row, formatParameters(rule.parameters));
+      return row;
+    });
+    el("rules-body").replaceChildren(...rows);
+  } catch {
+    el("score-bands").textContent = "Politique momentanément indisponible";
+  }
+}
+
+function clearFieldErrors() {
+  for (const field of form.elements) {
+    if (!field.name) continue;
+    field.removeAttribute("aria-invalid");
+    const error = el(`${field.name}-error`);
+    if (error) error.textContent = "";
+  }
+  el("form-message").textContent = "";
+}
+
+function showFieldErrors(errors) {
+  clearFieldErrors();
+  for (const [name, message] of Object.entries(errors)) {
+    const field = form.elements.namedItem(name);
+    if (field instanceof HTMLElement) field.setAttribute("aria-invalid", "true");
+    const error = el(`${name}-error`);
+    if (error) error.textContent = message;
+  }
+  el("form-message").textContent = "Corrigez les champs signalés avant l’évaluation.";
+  const firstInvalid = form.querySelector('[aria-invalid="true"]');
+  firstInvalid?.focus();
+}
+
+function draftFromForm() {
+  return Object.fromEntries(new FormData(form).entries());
+}
+
+function setFormValues(transaction) {
+  for (const [name, value] of Object.entries(transaction)) {
+    const field = form.elements.namedItem(name);
+    if (field && "value" in field) field.value = String(value);
+  }
+  clearFieldErrors();
+}
+
+function loadScenario(name) {
+  const scenario = SCENARIOS[name];
+  if (!scenario) return;
+  setFormValues({ transactionId: newTransactionId(), ...scenario.transaction });
+  for (const button of document.querySelectorAll("[data-scenario]")) {
+    button.setAttribute("aria-pressed", String(button.dataset.scenario === name));
+  }
+}
+
+function verdictChip(verdict) {
+  const chip = document.createElement("span");
+  chip.className = `verdict-chip verdict-${verdict.toLowerCase()}`;
+  chip.textContent = verdict;
+  return chip;
+}
+
+function renderDecision(decision, degraded) {
+  el("result-empty").classList.add("hidden");
+  const article = el("decision");
+  article.classList.remove("hidden");
+  article.dataset.verdict = decision.decision;
+  el("decision-verdict").textContent = decision.decision;
+  el("decision-score").textContent = String(decision.score);
+  el("decision-copy").textContent = decisionMessages[decision.decision] ?? "Décision calculée.";
+  el("decision-id").textContent = decision.decisionId;
+  el("decision-time").textContent = new Date(decision.evaluatedAt).toLocaleString("fr-FR");
+
+  const mode = el("decision-mode");
+  mode.textContent = degraded ? "Mode dégradé" : "Mode normal";
+  mode.className = `mode-badge mode-${degraded ? "degraded" : "normal"}`;
+
+  const reasons = decision.reasons.map((reason) => {
+    const item = document.createElement("li");
+    const name = document.createElement("strong");
+    name.textContent = reason.rule;
+    const weight = document.createElement("span");
+    weight.textContent = reason.weight > 0 ? `+${reason.weight}` : "contexte";
+    const detail = document.createElement("small");
+    detail.textContent = reason.detail;
+    item.append(name, weight, detail);
+    return item;
+  });
+  if (reasons.length === 0) {
+    const item = document.createElement("li");
+    const name = document.createElement("strong");
+    name.textContent = "Aucune règle déclenchée";
+    item.append(name);
+    reasons.push(item);
+  }
+  el("decision-reasons").replaceChildren(...reasons);
+}
+
+function renderHistory() {
+  const entries = history.list();
+  const rows = entries.map((entry) => {
+    const row = document.createElement("tr");
+    textCell(row, new Date(entry.evaluatedAt).toLocaleTimeString("fr-FR"));
+    const verdict = document.createElement("td");
+    verdict.append(verdictChip(entry.decision));
+    row.append(verdict);
+    textCell(row, String(entry.score));
+    textCell(row, entry.reasons.map((reason) => reason.rule).join(", ") || "—");
+    textCell(row, entry.instanceId ?? "—", "rule-name");
+    return row;
+  });
+  el("history-body").replaceChildren(...rows);
+  el("history-empty").classList.toggle("hidden", entries.length > 0);
+}
+
+form.addEventListener("submit", async (event) => {
+  event.preventDefault();
+  clearFieldErrors();
+  const parsed = validateTransactionDraft(draftFromForm());
+  if (!parsed.ok) {
+    showFieldErrors(parsed.errors);
+    return;
+  }
+
+  const submitButton = el("submit-button");
+  submitButton.disabled = true;
+  submitButton.firstChild.textContent = "Évaluation en cours… ";
+  try {
+    const result = await submitTransaction(fetch, parsed.value, newIdempotencyKey());
+    tracker.observe(result.instanceId);
+    history.add({ ...result.decision, instanceId: result.instanceId });
+    renderDecision(result.decision, result.degraded);
+    renderHistory();
+    updateReplicaCount();
+    setServiceStatus(
+      result.degraded ? "degraded" : "normal",
+      result.degraded ? "Service dégradé · revue forcée" : "Service opérationnel",
+    );
+  } catch (error) {
+    el("form-message").textContent = error.message;
+    setServiceStatus("offline", "Évaluation indisponible");
+  } finally {
+    submitButton.disabled = false;
+    submitButton.firstChild.textContent = "Évaluer la transaction ";
+  }
+});
+
+for (const button of document.querySelectorAll("[data-scenario]")) {
+  button.addEventListener("click", () => loadScenario(button.dataset.scenario));
+}
+
+el("new-transaction").addEventListener("click", () => {
+  form.reset();
+  setFormValues({ transactionId: newTransactionId(), country: "FR", merchantCategory: "grocery" });
+  for (const button of document.querySelectorAll("[data-scenario]")) {
+    button.setAttribute("aria-pressed", "false");
+  }
+});
+
+el("clear-history").addEventListener("click", () => {
+  history.clear();
+  renderHistory();
+});
+
+loadScenario("approved");
+renderHistory();
+void loadRules();
+void refreshServiceStatus();
+setInterval(() => void refreshServiceStatus(), STATUS_POLL_MS);

--- a/web/app.test.mjs
+++ b/web/app.test.mjs
@@ -1,0 +1,179 @@
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { Window } from "happy-dom";
+
+const html = await readFile(new URL("./index.html", import.meta.url), "utf8");
+
+const rules = {
+  scoreBands: {
+    approved: { max: 29 },
+    review: { min: 30, max: 59 },
+    rejected: { min: 60, max: 100 },
+  },
+  rules: [
+    {
+      rule: "HIGH_AMOUNT",
+      weight: 20,
+      parameters: { threshold: 1_000, countries: ["FR", "DE"] },
+    },
+  ],
+};
+
+const decision = {
+  decisionId: "dec_web_1",
+  decision: "APPROVED",
+  score: 0,
+  reasons: [],
+  evaluatedAt: "2026-09-01T10:00:00.000Z",
+  degraded: false,
+};
+
+function response(payload, { status = 200, instanceId = "api-1", degraded = false } = {}) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: {
+      "content-type": "application/json",
+      "x-instance-id": instanceId,
+      "x-degraded-mode": String(degraded),
+    },
+  });
+}
+
+async function createPage(fetcher) {
+  const window = new Window({ url: "http://localhost/" });
+  window.document.write(html);
+  window.document.close();
+
+  const previous = new Map();
+  const globals = {
+    document: window.document,
+    HTMLElement: window.HTMLElement,
+    FormData: window.FormData,
+    fetch: fetcher,
+    setInterval: () => 1,
+  };
+  for (const [name, value] of Object.entries(globals)) {
+    previous.set(name, globalThis[name]);
+    globalThis[name] = value;
+  }
+
+  await import(`./app.mjs?test=${crypto.randomUUID()}`);
+  await window.happyDOM.waitUntilComplete();
+  await new Promise((resolve) => setImmediate(resolve));
+
+  return {
+    window,
+    restore() {
+      for (const [name, value] of previous) globalThis[name] = value;
+      window.close();
+    },
+  };
+}
+
+test("initialise le simulateur, charge les règles et soumet sans secret interservice", async (t) => {
+  const requests = [];
+  const page = await createPage(async (url, options = {}) => {
+    requests.push({ url, options });
+    if (url === "/ready") return response({ mode: "normal" }, { instanceId: "api-1" });
+    if (url === "/api/rules") return response(rules, { instanceId: "api-2" });
+    if (url === "/api/decisions") return response(decision, { instanceId: "api-2" });
+    return response({ error: "not_found" }, { status: 404 });
+  });
+  t.after(() => page.restore());
+
+  const { document, Event } = page.window;
+  assert.equal(document.querySelector("#status-label").textContent, "Service opérationnel");
+  assert.match(document.querySelector("#score-bands").textContent, /APPROVED 0–29/);
+  assert.equal(document.querySelectorAll("#rules-body tr").length, 1);
+  assert.equal(document.querySelector("#replica-count").textContent, "2");
+
+  document
+    .querySelector("#transaction-form")
+    .dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+  await page.window.happyDOM.waitUntilComplete();
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.equal(document.querySelector("#decision-verdict").textContent, "APPROVED");
+  assert.equal(document.querySelector("#decision-score").textContent, "0");
+  assert.equal(document.querySelectorAll("#decision-reasons li").length, 1);
+  assert.equal(document.querySelectorAll("#history-body tr").length, 1);
+  const submission = requests.find((entry) => entry.url === "/api/decisions");
+  assert.equal(submission.options.headers["x-api-key"], undefined);
+
+  document.querySelector('[data-scenario="review"]').click();
+  assert.equal(document.querySelector("#country").value, "US");
+  document.querySelector("#new-transaction").click();
+  assert.equal(document.querySelector("#country").value, "FR");
+  document.querySelector("#clear-history").click();
+  assert.equal(document.querySelectorAll("#history-body tr").length, 0);
+});
+
+test("affiche les validations locales et le mode dégradé sans approuver", async (t) => {
+  const degradedDecision = {
+    ...decision,
+    decisionId: "dec_web_degraded",
+    decision: "REVIEW",
+    score: 30,
+    degraded: true,
+    reasons: [
+      {
+        rule: "RISK_CONTEXT_UNAVAILABLE",
+        weight: 0,
+        detail: "Shared risk state is temporarily unavailable",
+      },
+    ],
+  };
+  const page = await createPage(async (url) => {
+    if (url === "/ready") return response({ mode: "degraded" }, { degraded: true });
+    if (url === "/api/rules") return response(rules);
+    return response(degradedDecision, { degraded: true });
+  });
+  t.after(() => page.restore());
+
+  const { document, Event } = page.window;
+  assert.match(document.querySelector("#status-label").textContent, /dégradé/);
+  document.querySelector("#transactionId").value = "?";
+  document
+    .querySelector("#transaction-form")
+    .dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+  assert.equal(document.querySelector("#transactionId").getAttribute("aria-invalid"), "true");
+
+  document.querySelector('[data-scenario="approved"]').click();
+  document
+    .querySelector("#transaction-form")
+    .dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+  await page.window.happyDOM.waitUntilComplete();
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(document.querySelector("#decision-verdict").textContent, "REVIEW");
+  assert.equal(document.querySelector("#decision-mode").textContent, "Mode dégradé");
+  assert.equal(
+    document.querySelector("#decision-reasons strong").textContent,
+    "RISK_CONTEXT_UNAVAILABLE",
+  );
+});
+
+test("rend explicites les pannes de lecture et d’évaluation", async (t) => {
+  const page = await createPage(async (url) => {
+    if (url === "/api/decisions") {
+      return response({ error: "service_unavailable" }, { status: 503, instanceId: "api-3" });
+    }
+    throw new Error("network unavailable");
+  });
+  t.after(() => page.restore());
+
+  const { document, Event } = page.window;
+  assert.equal(document.querySelector("#status-label").textContent, "API indisponible");
+  assert.equal(
+    document.querySelector("#score-bands").textContent,
+    "Politique momentanément indisponible",
+  );
+
+  document
+    .querySelector("#transaction-form")
+    .dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+  await page.window.happyDOM.waitUntilComplete();
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.match(document.querySelector("#form-message").textContent, /momentanément indisponible/);
+  assert.equal(document.querySelector("#status-label").textContent, "Évaluation indisponible");
+});

--- a/web/dev-server.mjs
+++ b/web/dev-server.mjs
@@ -1,0 +1,88 @@
+/**
+ * Serveur de développement local — le remplaçant de nginx tant que la brique
+ * Docker n'existe pas. Deux rôles, exactement ceux de nginx en production :
+ *   1. sert les fichiers statiques de `web/` ;
+ *   2. relaie `/api/*` vers l'API en injectant `X-API-Key` côté serveur, pour
+ *      que la clé n'atteigne jamais le navigateur.
+ *
+ * Zéro dépendance : uniquement des modules natifs de Node.
+ *   node --env-file-if-exists=../.env web/dev-server.mjs
+ */
+import { createServer, request as proxyRequest } from "node:http";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { dirname, extname, join, normalize } from "node:path";
+
+const WEB_DIR = dirname(fileURLToPath(import.meta.url));
+const PORT = Number(process.env.WEB_PORT ?? 8080);
+const API_ORIGIN = process.env.API_ORIGIN ?? "http://localhost:3000";
+const API_KEY = process.env.API_KEY ?? "";
+
+const CONTENT_TYPE = {
+  ".html": "text/html; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".mjs": "text/javascript; charset=utf-8",
+};
+
+function relayToApi(clientRequest, clientResponse) {
+  const target = new URL(clientRequest.url, API_ORIGIN);
+  const headers = { ...clientRequest.headers, host: target.host };
+  delete headers["x-api-key"];
+  delete headers["x-load-test-token"];
+  if (API_KEY) headers["x-api-key"] = API_KEY;
+
+  const upstream = proxyRequest(
+    target,
+    { method: clientRequest.method, headers },
+    (upstreamResponse) => {
+      clientResponse.writeHead(upstreamResponse.statusCode ?? 502, upstreamResponse.headers);
+      upstreamResponse.pipe(clientResponse);
+    },
+  );
+  upstream.on("error", () => {
+    clientResponse.writeHead(502, { "content-type": "application/json" });
+    clientResponse.end(JSON.stringify({ error: "bad_gateway" }));
+  });
+  clientRequest.pipe(upstream);
+}
+
+async function serveStatic(clientRequest, clientResponse) {
+  const requestedPath = (clientRequest.url ?? "/").split("?")[0];
+  const relative = normalize(requestedPath === "/" ? "/index.html" : requestedPath);
+  const file = join(WEB_DIR, relative);
+  if (!file.startsWith(WEB_DIR)) {
+    clientResponse.writeHead(403).end("forbidden");
+    return;
+  }
+  try {
+    const body = await readFile(file);
+    clientResponse.writeHead(200, {
+      "content-type": CONTENT_TYPE[extname(file)] ?? "application/octet-stream",
+      "cache-control": "no-store",
+      "content-security-policy":
+        "default-src 'self'; object-src 'none'; base-uri 'none'; frame-ancestors 'none'; form-action 'self'",
+      "referrer-policy": "no-referrer",
+      "x-content-type-options": "nosniff",
+      "x-frame-options": "DENY",
+    });
+    clientResponse.end(body);
+  } catch {
+    clientResponse.writeHead(404).end("not found");
+  }
+}
+
+createServer((clientRequest, clientResponse) => {
+  if (
+    (clientRequest.url ?? "").startsWith("/api/") ||
+    (clientRequest.url ?? "").split("?", 1)[0] === "/ready"
+  ) {
+    relayToApi(clientRequest, clientResponse);
+  } else {
+    void serveStatic(clientRequest, clientResponse);
+  }
+}).listen(PORT, () => {
+  console.log(`web  → http://localhost:${PORT}`);
+  console.log(
+    `api  → ${API_ORIGIN}  ·  X-API-Key : ${API_KEY ? "injectée" : "ABSENTE (définis API_KEY)"}`,
+  );
+});

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,252 @@
+<!doctype html>
+<html lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="Simulateur explicable de risque transactionnel" />
+    <title>Transaction Risk Gate</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <header class="topbar">
+      <a class="brand" href="#main" aria-label="Transaction Risk Gate, aller au contenu">
+        <span class="brand-mark" aria-hidden="true">TRG</span>
+        <span>
+          <strong>Transaction Risk Gate</strong>
+          <small>Décision de risque explicable</small>
+        </span>
+      </a>
+      <div class="runtime" aria-label="État du service">
+        <span class="runtime-item"
+          ><strong id="replica-count">0</strong> replica(s) observé(s)</span
+        >
+        <span class="status status-loading" id="status" role="status" aria-live="polite">
+          <span class="status-dot" aria-hidden="true"></span>
+          <span id="status-label">Connexion…</span>
+        </span>
+      </div>
+    </header>
+
+    <main id="main">
+      <section class="intro" aria-labelledby="intro-title">
+        <p class="eyebrow">Démonstrateur bancaire</p>
+        <h1 id="intro-title">Comprendre une décision, pas seulement recevoir un score.</h1>
+        <p>
+          Simulez une transaction synthétique. Le moteur applique cinq règles déterministes et
+          explique chaque signal déclenché, sans conserver de donnée métier durable.
+        </p>
+      </section>
+
+      <div class="workspace">
+        <section class="panel simulator" aria-labelledby="simulator-title">
+          <div class="panel-heading">
+            <div>
+              <p class="step">01 · Entrée</p>
+              <h2 id="simulator-title">Nouvelle transaction</h2>
+            </div>
+            <button class="button button-ghost" type="button" id="new-transaction">
+              Réinitialiser
+            </button>
+          </div>
+
+          <fieldset class="scenarios">
+            <legend>Charger un scénario</legend>
+            <div class="scenario-grid">
+              <button class="scenario scenario-approved" type="button" data-scenario="approved">
+                <span>APPROVED</span>
+                Transaction habituelle
+              </button>
+              <button class="scenario scenario-review" type="button" data-scenario="review">
+                <span>REVIEW</span>
+                Contexte à vérifier
+              </button>
+              <button class="scenario scenario-rejected" type="button" data-scenario="rejected">
+                <span>REJECTED</span>
+                Signaux cumulés
+              </button>
+            </div>
+          </fieldset>
+
+          <form id="transaction-form" novalidate>
+            <div class="form-grid">
+              <div class="field field-wide">
+                <label for="transactionId">Identifiant de transaction</label>
+                <input
+                  id="transactionId"
+                  name="transactionId"
+                  autocomplete="off"
+                  aria-describedby="transactionId-error"
+                  required
+                />
+                <span class="field-error" id="transactionId-error"></span>
+              </div>
+              <div class="field field-wide">
+                <label for="cardId">Identifiant de carte synthétique</label>
+                <input
+                  id="cardId"
+                  name="cardId"
+                  autocomplete="off"
+                  aria-describedby="cardId-hint cardId-error"
+                  required
+                />
+                <span class="field-hint" id="cardId-hint">
+                  Donnée de démonstration, jamais une vraie carte.
+                </span>
+                <span class="field-error" id="cardId-error"></span>
+              </div>
+              <div class="field">
+                <label for="amount">Montant</label>
+                <div class="input-suffix">
+                  <input
+                    id="amount"
+                    name="amount"
+                    type="number"
+                    min="0.01"
+                    step="0.01"
+                    aria-describedby="amount-error currency-error"
+                    required
+                  />
+                  <span>EUR</span>
+                </div>
+                <input name="currency" type="hidden" value="EUR" />
+                <span class="field-error" id="amount-error"></span>
+                <span class="field-error" id="currency-error"></span>
+              </div>
+              <div class="field">
+                <label for="country">Pays</label>
+                <input
+                  id="country"
+                  name="country"
+                  maxlength="2"
+                  placeholder="FR"
+                  aria-describedby="country-error"
+                  required
+                />
+                <span class="field-error" id="country-error"></span>
+              </div>
+              <div class="field">
+                <label for="channel">Canal</label>
+                <select id="channel" name="channel" aria-describedby="channel-error" required>
+                  <option value="in_store">En magasin</option>
+                  <option value="online">En ligne</option>
+                </select>
+                <span class="field-error" id="channel-error"></span>
+              </div>
+              <div class="field">
+                <label for="merchantCategory">Catégorie marchande</label>
+                <input
+                  id="merchantCategory"
+                  name="merchantCategory"
+                  autocomplete="off"
+                  placeholder="grocery"
+                  aria-describedby="merchantCategory-error"
+                  required
+                />
+                <span class="field-error" id="merchantCategory-error"></span>
+              </div>
+            </div>
+
+            <div class="form-message" id="form-message" role="alert" aria-live="assertive"></div>
+            <button class="button button-primary" id="submit-button" type="submit">
+              Évaluer la transaction
+              <span aria-hidden="true">→</span>
+            </button>
+          </form>
+        </section>
+
+        <section class="panel result-panel" aria-labelledby="result-title">
+          <div class="panel-heading">
+            <div>
+              <p class="step">02 · Décision</p>
+              <h2 id="result-title">Résultat expliqué</h2>
+            </div>
+            <span class="mode-badge" id="decision-mode">En attente</span>
+          </div>
+
+          <div class="result-empty" id="result-empty">
+            <span class="result-empty-mark" aria-hidden="true">?</span>
+            <p>Choisissez un scénario ou renseignez le formulaire pour obtenir une décision.</p>
+          </div>
+
+          <article class="decision hidden" id="decision" aria-live="polite">
+            <div class="decision-summary">
+              <div>
+                <p class="decision-label">Décision</p>
+                <strong class="decision-verdict" id="decision-verdict">—</strong>
+              </div>
+              <div class="score" aria-label="Score de risque">
+                <strong id="decision-score">0</strong>
+                <span>/ 100</span>
+              </div>
+            </div>
+            <p class="decision-copy" id="decision-copy"></p>
+            <div class="decision-meta">
+              <span id="decision-id"></span>
+              <span id="decision-time"></span>
+            </div>
+            <h3>Règles déclenchées</h3>
+            <ul class="reason-list" id="decision-reasons"></ul>
+          </article>
+        </section>
+      </div>
+
+      <section class="panel rules-panel" aria-labelledby="rules-title">
+        <div class="panel-heading">
+          <div>
+            <p class="step">03 · Politique</p>
+            <h2 id="rules-title">Règles actives</h2>
+          </div>
+          <p class="bands" id="score-bands">Chargement de la politique…</p>
+        </div>
+        <div class="table-scroll">
+          <table>
+            <thead>
+              <tr>
+                <th>Règle</th>
+                <th>Poids</th>
+                <th>Paramètres actifs</th>
+              </tr>
+            </thead>
+            <tbody id="rules-body"></tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="panel history-panel" aria-labelledby="history-title">
+        <div class="panel-heading">
+          <div>
+            <p class="step">Session locale</p>
+            <h2 id="history-title">Historique de cette page</h2>
+          </div>
+          <button class="button button-ghost" id="clear-history" type="button">Effacer</button>
+        </div>
+        <p class="privacy-note">
+          Conservé uniquement en mémoire dans cet onglet. Aucune liste globale n’est exposée par
+          l’API.
+        </p>
+        <div class="table-scroll">
+          <table>
+            <thead>
+              <tr>
+                <th>Heure</th>
+                <th>Décision</th>
+                <th>Score</th>
+                <th>Règles</th>
+                <th>Instance</th>
+              </tr>
+            </thead>
+            <tbody id="history-body"></tbody>
+          </table>
+        </div>
+        <p class="empty" id="history-empty">Aucune décision dans cette session.</p>
+      </section>
+    </main>
+
+    <footer>
+      <span>Transaction Risk Gate · Démonstrateur d’ingénierie</span>
+      <span>Règles heuristiques · EUR uniquement · Aucune donnée réelle</span>
+    </footer>
+
+    <script type="module" src="app.mjs"></script>
+  </body>
+</html>

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,0 +1,848 @@
+{
+  "name": "transaction-risk-gate-web",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "transaction-risk-gate-web",
+      "devDependencies": {
+        "c8": "12.0.0",
+        "happy-dom": "20.12.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+      "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "26.4.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.0.tgz",
+      "integrity": "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/buffer-image-size": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
+      "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/c8": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/c8/-/c8-12.0.0.tgz",
+      "integrity": "sha512-4zpJvrd1nKWutnnKC2pXkFmb6iM1l+ffN//o1CzlTNwW7GSOs9a1xrLqkC48nU8oEkjmPZLPiwMsIaOvoF4Pqg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.1",
+        "@istanbuljs/schema": "^0.1.3",
+        "find-up": "^5.0.0",
+        "foreground-child": "^3.1.1",
+        "istanbul-lib-coverage": "^3.2.0",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.1.6",
+        "test-exclude": "^8.0.0",
+        "v8-to-istanbul": "^9.0.0",
+        "yargs": "^18.0.0",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "c8": "bin/c8.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      },
+      "peerDependencies": {
+        "monocart-coverage-reports": "^2"
+      },
+      "peerDependenciesMeta": {
+        "monocart-coverage-reports": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/happy-dom": {
+      "version": "20.12.0",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.12.0.tgz",
+      "integrity": "sha512-7uMYJu2SEwwL8vVcKp0C0lnt6d2LSGGe+T+oY79PiCJNNSgFpbxW8n5KuzpDQvrU4mt+fYiK1+Jy7Z2v39YR6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "buffer-image-size": "^0.6.4",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-8.0.0.tgz",
+      "integrity": "sha512-ZOffsNrXYggvU1mDGHk54I96r26P8SyMjO5slMKSc7+IWmtB/MQKnEC2fP51imB3/pT6YK5cT5E8f+Dd9KdyOQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^13.0.6",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.1.0.tgz",
+      "integrity": "sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^8.2.1",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "transaction-risk-gate-web",
+  "private": true,
+  "type": "module",
+  "description": "Simulateur explicable — HTML/CSS/JavaScript sans dépendance runtime.",
+  "scripts": {
+    "dev": "node --env-file-if-exists=../.env dev-server.mjs",
+    "test": "node --test",
+    "test:coverage": "c8 --all --include=*.mjs --exclude=*.test.mjs --exclude=dev-server.mjs --reporter=text --reporter=lcov --reporter=json-summary --check-coverage --lines=80 --branches=80 --functions=80 --statements=80 node --test"
+  },
+  "devDependencies": {
+    "c8": "12.0.0",
+    "happy-dom": "20.12.0"
+  }
+}

--- a/web/replica-tracker.mjs
+++ b/web/replica-tracker.mjs
@@ -1,0 +1,23 @@
+/**
+ * Déduit le nombre de replicas actifs des en-têtes `X-Instance-Id` vus dans les
+ * réponses. Une instance revue dans la dernière fenêtre `ttlMs` compte ; au-delà
+ * elle est oubliée (scale-in, ou instance qui ne répond plus). Aucun appel à
+ * Azure : l'information est déjà dans les réponses que le tableau de bord reçoit.
+ */
+export function createReplicaTracker(ttlMs = 30_000) {
+  /** @type {Map<string, number>} identifiant d'instance -> instant de la dernière réponse */
+  const lastSeen = new Map();
+
+  return {
+    observe(instanceId, now = Date.now()) {
+      if (instanceId) lastSeen.set(instanceId, now);
+    },
+
+    count(now = Date.now()) {
+      for (const [instanceId, seenAt] of lastSeen) {
+        if (now - seenAt > ttlMs) lastSeen.delete(instanceId);
+      }
+      return lastSeen.size;
+    },
+  };
+}

--- a/web/replica-tracker.test.mjs
+++ b/web/replica-tracker.test.mjs
@@ -1,0 +1,33 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createReplicaTracker } from "./replica-tracker.mjs";
+
+test("compte les identifiants distincts vus dans la fenêtre", () => {
+  const tracker = createReplicaTracker(30_000);
+  tracker.observe("api-1", 0);
+  tracker.observe("api-2", 0);
+  tracker.observe("api-1", 0);
+  assert.equal(tracker.count(0), 2);
+});
+
+test("oublie une instance vue il y a plus de ttlMs", () => {
+  const tracker = createReplicaTracker(30_000);
+  tracker.observe("api-1", 0);
+  tracker.observe("api-2", 25_000);
+  assert.equal(tracker.count(31_000), 1); // api-1 périmé, api-2 encore là
+});
+
+test("une instance revue rafraîchit son horodatage", () => {
+  const tracker = createReplicaTracker(30_000);
+  tracker.observe("api-1", 0);
+  tracker.observe("api-1", 20_000);
+  assert.equal(tracker.count(40_000), 1); // revue à 20 s, pas périmée à 40 s
+});
+
+test("ignore une valeur absente", () => {
+  const tracker = createReplicaTracker();
+  tracker.observe(null);
+  tracker.observe("");
+  tracker.observe(undefined);
+  assert.equal(tracker.count(), 0);
+});

--- a/web/style.css
+++ b/web/style.css
@@ -1,0 +1,666 @@
+:root {
+  color-scheme: dark;
+  --bg: #080b11;
+  --surface: #10151e;
+  --surface-2: #151c27;
+  --border: #263142;
+  --border-strong: #3a485e;
+  --text: #f1f5f9;
+  --muted: #93a1b5;
+  --blue: #5aa7ff;
+  --blue-deep: #1268d6;
+  --approved: #4ade80;
+  --approved-soft: rgba(74, 222, 128, 0.12);
+  --review: #fbbf24;
+  --review-soft: rgba(251, 191, 36, 0.12);
+  --rejected: #fb7185;
+  --rejected-soft: rgba(251, 113, 133, 0.12);
+  --radius: 14px;
+  --shadow: 0 22px 70px rgba(0, 0, 0, 0.28);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  min-width: 320px;
+  margin: 0;
+  background:
+    radial-gradient(circle at 18% -10%, rgba(18, 104, 214, 0.2), transparent 32rem), var(--bg);
+  color: var(--text);
+  font-size: 15px;
+  line-height: 1.55;
+}
+
+button,
+input,
+select {
+  font: inherit;
+}
+button {
+  color: inherit;
+}
+
+.topbar {
+  position: sticky;
+  z-index: 10;
+  top: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 14px max(24px, calc((100vw - 1240px) / 2));
+  border-bottom: 1px solid rgba(58, 72, 94, 0.7);
+  background: rgba(8, 11, 17, 0.86);
+  backdrop-filter: blur(16px);
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  color: inherit;
+  text-decoration: none;
+}
+
+.brand-mark {
+  display: grid;
+  width: 42px;
+  height: 42px;
+  place-items: center;
+  border: 1px solid #377aca;
+  border-radius: 12px;
+  background: linear-gradient(145deg, #173e70, #0d2440);
+  color: #b9dcff;
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+}
+
+.brand strong,
+.brand small {
+  display: block;
+}
+.brand strong {
+  font-size: 14px;
+  letter-spacing: 0.01em;
+}
+.brand small {
+  margin-top: 1px;
+  color: var(--muted);
+  font-size: 11px;
+}
+
+.runtime {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+.runtime-item {
+  color: var(--muted);
+  font-size: 12px;
+}
+.runtime-item strong {
+  color: var(--blue);
+  font-variant-numeric: tabular-nums;
+}
+
+.status {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 11px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--surface);
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.status-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--muted);
+}
+.status-normal .status-dot {
+  background: var(--approved);
+  box-shadow: 0 0 0 4px var(--approved-soft);
+}
+.status-degraded .status-dot {
+  background: var(--review);
+  box-shadow: 0 0 0 4px var(--review-soft);
+}
+.status-offline .status-dot {
+  background: var(--rejected);
+  box-shadow: 0 0 0 4px var(--rejected-soft);
+}
+
+main {
+  width: min(1240px, calc(100% - 40px));
+  margin: 0 auto;
+  padding: 68px 0 52px;
+}
+
+.intro {
+  max-width: 760px;
+  margin-bottom: 38px;
+}
+.eyebrow,
+.step {
+  margin: 0 0 8px;
+  color: var(--blue);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+}
+.intro h1 {
+  max-width: 720px;
+  margin: 0;
+  font-size: clamp(32px, 5vw, 54px);
+  line-height: 1.04;
+  letter-spacing: -0.035em;
+}
+.intro > p:last-child {
+  max-width: 650px;
+  margin: 20px 0 0;
+  color: var(--muted);
+  font-size: 17px;
+}
+
+.workspace {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(340px, 0.85fr);
+  gap: 20px;
+  align-items: start;
+}
+
+.panel {
+  padding: 24px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: linear-gradient(155deg, rgba(21, 28, 39, 0.94), rgba(13, 18, 26, 0.96));
+  box-shadow: var(--shadow);
+}
+
+.panel-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 18px;
+  margin-bottom: 22px;
+}
+.panel h2 {
+  margin: 0;
+  font-size: 20px;
+  letter-spacing: -0.015em;
+}
+.panel h3 {
+  margin: 24px 0 10px;
+  font-size: 12px;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.button {
+  display: inline-flex;
+  min-height: 42px;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  padding: 9px 15px;
+  border: 1px solid transparent;
+  border-radius: 9px;
+  cursor: pointer;
+  font-weight: 700;
+  transition: 150ms ease;
+}
+.button:hover {
+  transform: translateY(-1px);
+}
+.button:focus-visible,
+.scenario:focus-visible,
+input:focus-visible,
+select:focus-visible {
+  outline: 3px solid rgba(90, 167, 255, 0.35);
+  outline-offset: 2px;
+}
+.button:disabled {
+  cursor: wait;
+  opacity: 0.6;
+  transform: none;
+}
+.button-primary {
+  width: 100%;
+  margin-top: 8px;
+  background: linear-gradient(135deg, #1976e8, #0b57b7);
+  color: white;
+  box-shadow: 0 10px 28px rgba(18, 104, 214, 0.25);
+}
+.button-primary:hover {
+  background: linear-gradient(135deg, #2885f5, #1268d6);
+}
+.button-ghost {
+  min-height: 34px;
+  padding: 6px 10px;
+  border-color: var(--border);
+  background: transparent;
+  color: var(--muted);
+  font-size: 12px;
+}
+.button-ghost:hover {
+  border-color: var(--border-strong);
+  color: var(--text);
+}
+
+.scenarios {
+  min-width: 0;
+  margin: 0 0 24px;
+  padding: 0;
+  border: 0;
+}
+.scenarios legend {
+  margin-bottom: 9px;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+}
+.scenario-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+}
+.scenario {
+  min-width: 0;
+  padding: 11px;
+  border: 1px solid var(--border);
+  border-radius: 9px;
+  background: rgba(8, 11, 17, 0.48);
+  text-align: left;
+  cursor: pointer;
+  color: var(--muted);
+  font-size: 11px;
+}
+.scenario span {
+  display: block;
+  margin-bottom: 4px;
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.05em;
+}
+.scenario:hover,
+.scenario[aria-pressed="true"] {
+  border-color: var(--border-strong);
+  background: var(--surface-2);
+  color: var(--text);
+}
+.scenario-approved span {
+  color: var(--approved);
+}
+.scenario-review span {
+  color: var(--review);
+}
+.scenario-rejected span {
+  color: var(--rejected);
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+.field {
+  min-width: 0;
+}
+.field-wide {
+  grid-column: span 2;
+}
+.field label {
+  display: block;
+  margin-bottom: 6px;
+  color: #c8d1df;
+  font-size: 12px;
+  font-weight: 700;
+}
+.field input,
+.field select {
+  width: 100%;
+  height: 43px;
+  padding: 9px 11px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: #0b1018;
+  color: var(--text);
+  transition: border-color 140ms ease;
+}
+.field input:hover,
+.field select:hover {
+  border-color: var(--border-strong);
+}
+.field input[aria-invalid="true"],
+.field select[aria-invalid="true"] {
+  border-color: var(--rejected);
+}
+.field-hint,
+.field-error {
+  display: block;
+  min-height: 17px;
+  margin-top: 4px;
+  font-size: 11px;
+}
+.field-hint {
+  color: var(--muted);
+}
+.field-error {
+  color: var(--rejected);
+}
+.input-suffix {
+  position: relative;
+}
+.input-suffix input {
+  padding-right: 48px;
+}
+.input-suffix span {
+  position: absolute;
+  top: 12px;
+  right: 11px;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 800;
+}
+.form-message {
+  min-height: 22px;
+  margin-top: 8px;
+  color: var(--rejected);
+  font-size: 12px;
+}
+
+.mode-badge {
+  padding: 5px 9px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--muted);
+  font-size: 10px;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+.mode-normal {
+  border-color: rgba(74, 222, 128, 0.35);
+  background: var(--approved-soft);
+  color: var(--approved);
+}
+.mode-degraded {
+  border-color: rgba(251, 191, 36, 0.35);
+  background: var(--review-soft);
+  color: var(--review);
+}
+
+.result-empty {
+  display: grid;
+  min-height: 365px;
+  place-items: center;
+  align-content: center;
+  gap: 16px;
+  color: var(--muted);
+  text-align: center;
+}
+.result-empty-mark {
+  display: grid;
+  width: 68px;
+  height: 68px;
+  place-items: center;
+  border: 1px dashed var(--border-strong);
+  border-radius: 50%;
+  color: var(--blue);
+  font-size: 26px;
+}
+.result-empty p {
+  max-width: 290px;
+  margin: 0;
+}
+.hidden {
+  display: none !important;
+}
+
+.decision-summary {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 22px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: #0b1018;
+}
+.decision-label {
+  margin: 0 0 3px;
+  color: var(--muted);
+  font-size: 11px;
+  text-transform: uppercase;
+}
+.decision-verdict {
+  font-size: 29px;
+  letter-spacing: -0.03em;
+}
+.decision[data-verdict="APPROVED"] .decision-verdict {
+  color: var(--approved);
+}
+.decision[data-verdict="REVIEW"] .decision-verdict {
+  color: var(--review);
+}
+.decision[data-verdict="REJECTED"] .decision-verdict {
+  color: var(--rejected);
+}
+.score {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+.score strong {
+  font-size: 34px;
+}
+.score span {
+  color: var(--muted);
+  font-size: 12px;
+}
+.decision-copy {
+  margin: 18px 0;
+  color: #c5cedb;
+}
+.decision-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 18px;
+  padding-bottom: 18px;
+  border-bottom: 1px solid var(--border);
+  color: var(--muted);
+  font:
+    11px ui-monospace,
+    "SFMono-Regular",
+    Consolas,
+    monospace;
+}
+.reason-list {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.reason-list li {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 4px 14px;
+  padding: 11px 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: rgba(8, 11, 17, 0.45);
+}
+.reason-list strong {
+  font-size: 12px;
+}
+.reason-list span {
+  color: var(--blue);
+  font-size: 12px;
+  font-weight: 800;
+}
+.reason-list small {
+  grid-column: 1 / -1;
+  color: var(--muted);
+}
+
+.rules-panel,
+.history-panel {
+  margin-top: 20px;
+}
+.bands {
+  margin: 4px 0 0;
+  color: var(--muted);
+  font-size: 12px;
+}
+.table-scroll {
+  overflow-x: auto;
+}
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+th,
+td {
+  padding: 12px 10px;
+  border-bottom: 1px solid var(--border);
+  text-align: left;
+  vertical-align: top;
+}
+th {
+  color: var(--muted);
+  font-size: 10px;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+td {
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+tbody tr:last-child td {
+  border-bottom: 0;
+}
+.rule-name {
+  color: #d7e2ef;
+  font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+}
+.weight {
+  color: var(--blue);
+  font-weight: 800;
+}
+.privacy-note,
+.empty {
+  color: var(--muted);
+  font-size: 12px;
+}
+.privacy-note {
+  margin: -10px 0 14px;
+}
+.verdict-chip {
+  display: inline-flex;
+  padding: 3px 7px;
+  border-radius: 5px;
+  font-size: 10px;
+  font-weight: 800;
+}
+.verdict-approved {
+  background: var(--approved-soft);
+  color: var(--approved);
+}
+.verdict-review {
+  background: var(--review-soft);
+  color: var(--review);
+}
+.verdict-rejected {
+  background: var(--rejected-soft);
+  color: var(--rejected);
+}
+
+footer {
+  display: flex;
+  justify-content: space-between;
+  gap: 18px;
+  width: min(1240px, calc(100% - 40px));
+  margin: 0 auto;
+  padding: 24px 0 40px;
+  border-top: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 11px;
+}
+
+@media (max-width: 900px) {
+  .workspace {
+    grid-template-columns: 1fr;
+  }
+  .result-empty {
+    min-height: 220px;
+  }
+}
+
+@media (max-width: 640px) {
+  .topbar {
+    position: static;
+    align-items: flex-start;
+    padding: 14px 16px;
+  }
+  .brand small,
+  .runtime-item {
+    display: none;
+  }
+  .runtime {
+    gap: 6px;
+  }
+  main {
+    width: min(100% - 24px, 1240px);
+    padding-top: 42px;
+  }
+  .intro h1 {
+    font-size: 34px;
+  }
+  .panel {
+    padding: 18px;
+  }
+  .scenario-grid {
+    grid-template-columns: 1fr;
+  }
+  .form-grid {
+    grid-template-columns: 1fr;
+  }
+  .field-wide {
+    grid-column: auto;
+  }
+  .panel-heading {
+    align-items: center;
+  }
+  footer {
+    width: calc(100% - 24px);
+    flex-direction: column;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition: none !important;
+  }
+}

--- a/web/transaction-simulator.mjs
+++ b/web/transaction-simulator.mjs
@@ -1,0 +1,144 @@
+export const SCENARIOS = Object.freeze({
+  approved: Object.freeze({
+    label: "Transaction habituelle",
+    expected: "APPROVED",
+    transaction: Object.freeze({
+      cardId: "card_demo_safe",
+      amount: 42.5,
+      currency: "EUR",
+      country: "FR",
+      channel: "in_store",
+      merchantCategory: "grocery",
+    }),
+  }),
+  review: Object.freeze({
+    label: "Contexte à vérifier",
+    expected: "REVIEW",
+    transaction: Object.freeze({
+      cardId: "card_demo_review",
+      amount: 180,
+      currency: "EUR",
+      country: "US",
+      channel: "online",
+      merchantCategory: "travel",
+    }),
+  }),
+  rejected: Object.freeze({
+    label: "Cumul de signaux risqués",
+    expected: "REJECTED",
+    transaction: Object.freeze({
+      cardId: "card_demo_rejected",
+      amount: 2500,
+      currency: "EUR",
+      country: "US",
+      channel: "online",
+      merchantCategory: "crypto",
+    }),
+  }),
+});
+
+const IDENTIFIER = /^[A-Za-z0-9_-]{3,64}$/;
+const COUNTRY = /^[A-Z]{2}$/;
+const CHANNELS = new Set(["in_store", "online"]);
+
+export function validateTransactionDraft(draft) {
+  const errors = {};
+  const transactionId = String(draft.transactionId ?? "").trim();
+  const cardId = String(draft.cardId ?? "").trim();
+  const amount = Number(draft.amount);
+  const currency = String(draft.currency ?? "").toUpperCase();
+  const country = String(draft.country ?? "")
+    .trim()
+    .toUpperCase();
+  const channel = String(draft.channel ?? "");
+  const merchantCategory = String(draft.merchantCategory ?? "")
+    .trim()
+    .toLowerCase();
+
+  if (!IDENTIFIER.test(transactionId)) errors.transactionId = "3 à 64 caractères sûrs requis";
+  if (!IDENTIFIER.test(cardId)) errors.cardId = "3 à 64 caractères sûrs requis";
+  if (!Number.isFinite(amount) || amount <= 0 || amount > 1_000_000_000) {
+    errors.amount = "Montant EUR positif requis";
+  }
+  if (currency !== "EUR") errors.currency = "La version v1 accepte uniquement EUR";
+  if (!COUNTRY.test(country)) errors.country = "Code pays ISO sur deux lettres requis";
+  if (!CHANNELS.has(channel)) errors.channel = "Canal inconnu";
+  if (!/^[a-z][a-z0-9_]{1,63}$/.test(merchantCategory)) {
+    errors.merchantCategory = "Catégorie en minuscules requise";
+  }
+
+  if (Object.keys(errors).length > 0) return { ok: false, errors };
+  return {
+    ok: true,
+    value: {
+      transactionId,
+      cardId,
+      amount,
+      currency,
+      country,
+      channel,
+      merchantCategory,
+    },
+  };
+}
+
+export function createSessionHistory(maxEntries = 20) {
+  if (!Number.isInteger(maxEntries) || maxEntries < 1) {
+    throw new TypeError("maxEntries doit être un entier positif");
+  }
+  let entries = [];
+  return {
+    add(decision) {
+      entries = [structuredClone(decision), ...entries].slice(0, maxEntries);
+    },
+    list() {
+      return structuredClone(entries);
+    },
+    clear() {
+      entries = [];
+    },
+  };
+}
+
+export function newTransactionId(now = Date.now()) {
+  return `txn_${now.toString(36)}`;
+}
+
+export function newIdempotencyKey(randomId = crypto.randomUUID()) {
+  return `web:${randomId}`;
+}
+
+export async function submitTransaction(fetcher, transaction, idempotencyKey) {
+  const response = await fetcher("/api/decisions", {
+    method: "POST",
+    headers: {
+      accept: "application/json",
+      "content-type": "application/json",
+      "idempotency-key": idempotencyKey,
+    },
+    body: JSON.stringify(transaction),
+  });
+  const payload = await response.json().catch(() => ({ error: "invalid_api_response" }));
+  if (!response.ok) {
+    const error = new Error(userMessageForApiError(response.status, payload?.error));
+    error.status = response.status;
+    error.code = payload?.error;
+    throw error;
+  }
+  return {
+    decision: payload,
+    instanceId: response.headers.get("x-instance-id"),
+    degraded: response.headers.get("x-degraded-mode") === "true" || payload.degraded === true,
+  };
+}
+
+export function userMessageForApiError(status, code) {
+  if (status === 400) return "Les données envoyées ne respectent pas le contrat de l’API.";
+  if (status === 401) return "La passerelle web n’est pas correctement authentifiée.";
+  if (status === 409 || code === "idempotency_conflict") {
+    return "Cette clé d’idempotence appartient déjà à une autre transaction.";
+  }
+  if (status === 413) return "La requête dépasse la taille autorisée.";
+  if (status === 429) return "Trop de requêtes. Réessayez après quelques instants.";
+  return "Le service de décision est momentanément indisponible.";
+}

--- a/web/transaction-simulator.test.mjs
+++ b/web/transaction-simulator.test.mjs
@@ -1,0 +1,125 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  SCENARIOS,
+  createSessionHistory,
+  newIdempotencyKey,
+  submitTransaction,
+  userMessageForApiError,
+  validateTransactionDraft,
+} from "./transaction-simulator.mjs";
+
+const valid = {
+  transactionId: "txn_demo_1",
+  cardId: "card_demo_1",
+  amount: "42.50",
+  currency: "eur",
+  country: "fr",
+  channel: "in_store",
+  merchantCategory: "Grocery",
+};
+
+test("normalise une transaction valide avant envoi", () => {
+  const result = validateTransactionDraft(valid);
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.value, {
+    ...valid,
+    amount: 42.5,
+    currency: "EUR",
+    country: "FR",
+    merchantCategory: "grocery",
+  });
+});
+
+test("retourne toutes les erreurs de formulaire sans envoi partiel", () => {
+  const result = validateTransactionDraft({
+    transactionId: "?",
+    cardId: "",
+    amount: "-1",
+    currency: "USD",
+    country: "France",
+    channel: "phone",
+    merchantCategory: "!",
+  });
+  assert.equal(result.ok, false);
+  assert.deepEqual(Object.keys(result.errors).sort(), [
+    "amount",
+    "cardId",
+    "channel",
+    "country",
+    "currency",
+    "merchantCategory",
+    "transactionId",
+  ]);
+});
+
+test("les trois scénarios couvrent les verdicts attendus", () => {
+  assert.deepEqual(
+    Object.values(SCENARIOS).map((scenario) => scenario.expected),
+    ["APPROVED", "REVIEW", "REJECTED"],
+  );
+  for (const scenario of Object.values(SCENARIOS)) {
+    const result = validateTransactionDraft({
+      transactionId: "txn_scenario",
+      ...scenario.transaction,
+    });
+    assert.equal(result.ok, true);
+  }
+});
+
+test("historique de session garde les plus récentes et protège ses valeurs", () => {
+  const history = createSessionHistory(2);
+  const first = { decisionId: "dec_1" };
+  history.add(first);
+  first.decisionId = "mutated";
+  history.add({ decisionId: "dec_2" });
+  history.add({ decisionId: "dec_3" });
+  const listed = history.list();
+  assert.deepEqual(
+    listed.map((entry) => entry.decisionId),
+    ["dec_3", "dec_2"],
+  );
+  listed[0].decisionId = "changed";
+  assert.equal(history.list()[0].decisionId, "dec_3");
+});
+
+test("soumission n envoie jamais la clé interservice depuis le navigateur", async () => {
+  let captured;
+  const fetcher = async (url, options) => {
+    captured = { url, options };
+    return {
+      ok: true,
+      status: 200,
+      headers: new Headers({ "x-instance-id": "api-2" }),
+      json: async () => ({ decisionId: "dec_1", decision: "APPROVED", degraded: false }),
+    };
+  };
+  const result = await submitTransaction(fetcher, valid, "web:test-key-12345678");
+
+  assert.equal(captured.url, "/api/decisions");
+  assert.equal(captured.options.headers["x-api-key"], undefined);
+  assert.equal(captured.options.headers["idempotency-key"], "web:test-key-12345678");
+  assert.equal(result.instanceId, "api-2");
+  assert.equal(result.degraded, false);
+});
+
+test("transforme les erreurs API en messages actionnables", async () => {
+  const fetcher = async () => ({
+    ok: false,
+    status: 429,
+    headers: new Headers(),
+    json: async () => ({ error: "rate_limit_exceeded" }),
+  });
+  await assert.rejects(
+    () => submitTransaction(fetcher, valid, "web:test-key-12345678"),
+    /Trop de requêtes/,
+  );
+  assert.match(userMessageForApiError(409, "idempotency_conflict"), /idempotence/);
+});
+
+test("génère une clé d idempotence compatible avec le contrat", () => {
+  assert.equal(
+    newIdempotencyKey("123e4567-e89b-12d3-a456-426614174000"),
+    "web:123e4567-e89b-12d3-a456-426614174000",
+  );
+});


### PR DESCRIPTION
## Résultat attendu

Une démonstration claire du moteur de risque sans dépendre de Postman : un formulaire de transaction
validé, des scénarios prédéfinis `APPROVED` / `REVIEW` / `REJECTED`, l'affichage du score, de la
décision et des règles déclenchées, les états `normal` / `dégradé` / `indisponible` de l'API, les
règles actives, un historique limité à la session du navigateur, et un compteur de replicas déduit
des `X-Instance-Id` distincts.

## Travail et périmètre

- Issue : `TRG-5` / #14
- Branche source : `feat/TRG-5-simulateur-web` → `develop`
- Labels : `type:feat`, `risk:medium`, `area:web`, `release:required`
- Inclus : `web/index.html`, `web/style.css` (HTML/CSS à la main), `web/app.mjs`,
  `web/transaction-simulator.mjs`, `web/replica-tracker.mjs` + tests, `web/dev-server.mjs`
  (stand-in local de nginx, injecte `X-API-Key`). Étape web ajoutée au job `Tests existants`.
- Exclu : `web/Dockerfile`, `web/nginx.conf.template` — TRG-7.

## Risques et compatibilité

- Niveau de risque : medium — interface en observation seule, rendu par `textContent`.
- Impact sécurité : la clé de service n'atteint jamais le navigateur ; `dev-server.mjs` l'injecte
  côté serveur, comme le fera nginx.
- Rollback : `develop` reste vert sans cette PR.

## Vérification

- `npm run test:coverage --prefix web` : **14 tests**, **99,5 % lignes** (seuil 80), branches 86,2 %.
- `replica-tracker` : logique de péremption isolée et testée (fenêtre glissante).
- `prettier`, `markdownlint`, `validate-repository`, `pre-commit`, `pre-push` : verts.

## Notes pour le reviewer

Aucune bibliothèque de composants : HTML et CSS écrits à la main. Le tableau de bord poll
`/api/rules` + `/api/decisions` et n'écrit que via `textContent` (pas d'injection HTML).

Closes #14
