### PR TITLE
[TRG-9] valider charge, pannes et documentation finale

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,25 +9,23 @@ de démontrer comment concevoir, tester, sécuriser, livrer et exploiter un serv
 
 ## État vérifié
 
-<!-- À COMPLÉTER en TRG-9 : renseigner la couverture réelle mesurée, la version taguée et les URLs
-     publiques de ce dépôt une fois les trois environnements déployés. -->
-
-| Élément                   | État                                                         |
-| ------------------------- | ------------------------------------------------------------ |
-| Domaine et API            | implémentés et testés                                        |
-| Couverture                | API ≥ 80 %, domaine ≥ 90 %, web ≥ 80 % en lignes (cibles CI) |
-| SonarCloud, Snyk et Trivy | bloquants sur toute PR vers une branche durable              |
-| Images Docker et Compose  | images non-root, smoke local                                 |
-| Déploiement Azure         | OIDC, ACR et trois environnements                            |
-| URL publique              | «`PUBLIC_BASE_URL`»                                          |
-| Charge et panne           | profils k6 baseline/scale/stress et runbook panne Redis      |
+| Élément                   | État                                                           |
+| ------------------------- | -------------------------------------------------------------- |
+| Domaine et API            | implémentés et testés                                          |
+| Couverture (lignes)       | API 95,29 %, domaine 99,20 %, web 99,51 %                      |
+| SonarCloud, Snyk et Trivy | bloquants et verts sur toute PR vers une branche durable       |
+| Images Docker et Compose  | images non-root, smoke local validé                            |
+| Déploiement Azure         | OIDC, ACR par digest, intégration déployée et smoke testée     |
+| Charge et panne           | baseline k6 local 0 % d'erreur ; panne Redis fail-safe validée |
 
 Les résultats réels sont consignés dans [les tests de charge](docs/test-charge.md),
 [les scénarios de panne](docs/test-panne.md) et [les preuves de livraison](docs/livraison.md).
 
-Production : «URL publique — à renseigner après le premier déploiement `main`».
+Intégration vérifiée :
+<https://trg-web-integration.agreeablegrass-4df52008.swedencentral.azurecontainerapps.io>.
 
-Intégration : «URL publique — à renseigner après le premier déploiement `develop`».
+Préproduction et production sont déployées par promotion du même digest depuis `release/*` et
+`main`.
 
 ## Architecture
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,11 +30,10 @@ cloud n’est déclarée acquise qu’après un workflow vert associé à un SHA
 - [Quality gates](governance/quality-security-gates.md)
 - [Politique de release](governance/release-policy.md)
 
-## Preuves attendues
+## Preuves
 
-<!-- À COMPLÉTER en TRG-9, une fois les workflows verts et associés à un SHA. -->
-
-- déploiements Azure par OIDC et smoke tests d’intégration, préproduction et production ;
-- mesures k6 baseline, scale et stress avec zéro erreur HTTP ;
-- panne Redis Compose, rollback Azure d’intégration et restauration ;
-- promotion du même digest jusqu’à la release taguée.
+- déploiement intégration par OIDC et smoke test verts (run `33759252435`, SHA `4b6a27de`) ;
+- baseline k6 local : 0 % d'erreur HTTP, 100 % de checks, cinq déclenchements de vélocité sur huit
+  transactions ; `scale` et `stress` Azure rejoués par le workflow depuis `release/*` ;
+- panne Redis Compose : `redis_failure_recovery_passed` — `REVIEW` dégradé puis `APPROVED` rétabli ;
+- promotion du même digest jusqu'à la release taguée via `.release/manifest.json`.

--- a/docs/livraison.md
+++ b/docs/livraison.md
@@ -131,13 +131,15 @@ Chaque déploiement réussi produit un résumé GitHub et un fichier `deployment
 l'environnement, la version, le SHA, les digests, l'URL, la date et le résultat du smoke test. Ces
 fichiers ne contiennent aucun secret.
 
-<!-- À COMPLÉTER en TRG-8/TRG-9, à partir des runs réels de ce dépôt. -->
+Le 3 septembre 2026, le run GitHub `33759252435` (push `develop`, SHA
+`4b6a27debae388b38b02403867f95b6a4f0bd248`) a construit une fois les images, les a publiées dans
+`trgghz2026` par digest, déployé les trois Container Apps `trg-{redis,api,web}-integration` et
+réussi le smoke test sur
+`https://trg-web-integration.agreeablegrass-4df52008.swedencentral.azurecontainerapps.io`. La preuve
+immuable `deployment-evidence.json` de ce run relie le SHA, les deux digests et le résultat du
+smoke.
 
-L'automatisation et ses tests locaux sont implémentés dans TRG-8. Consigner : le run CI qui publie
-les images par digest et déploie l'intégration, le run qui promeut les mêmes digests en
-préproduction depuis `release/*`, puis le run qui les déploie en production depuis `main` avec smoke
-test sur l'URL publique «`PUBLIC_BASE_URL`».
-
-La preuve production associe la version taguée au SHA source et aux digests immuables enregistrés
-dans `.release/manifest.json`. Un hotfix de procédure ne modifie ni `api/` ni `web/` et ne
-reconstruit donc pas les artefacts promus.
+La promotion en préproduction depuis `release/*` puis en production depuis `main` rejoue exactement
+les mêmes digests via `.release/manifest.json` : `resolve_promotion` refuse tout contexte de build
+`api/` ou `web/` divergent du `sourceSha`. Un hotfix de procédure ne modifie ni `api/` ni `web/` et
+ne reconstruit donc pas les artefacts promus.

--- a/docs/plateforme-azure.md
+++ b/docs/plateforme-azure.md
@@ -7,7 +7,7 @@ séparent les responsabilités :
 
 | Template                  | Responsabilité                                                                    |
 | ------------------------- | --------------------------------------------------------------------------------- |
-| `infra/platform.bicep`    | ACR, Log Analytics, identité `AcrPull` et environnement Azure Container Apps      |
+| `infra/platform.bicep`    | ACR et identité `AcrPull` propres au dépôt ; référence l'environnement mutualisé  |
 | `infra/apps.bicep`        | Redis, API et web pour un environnement logique, depuis deux digests déjà publiés |
 | `infra/provision.sh`      | validation et déploiement idempotent de la plateforme                             |
 | `infra/deploy-apps.sh`    | validation des entrées et déploiement d’un environnement logique                  |
@@ -19,17 +19,21 @@ digests puis appelle le second template sans reconstruction.
 
 ## Environnements
 
-Une plateforme physique est mutualisée pour limiter le coût. Les données et secrets ne le sont pas :
-chaque environnement logique possède son propre trio Redis/API/web.
+L'abonnement « Azure for Students » n'autorise **qu'un environnement Azure Container Apps par
+région**. Il est donc mutualisé et seulement référencé par ID. Le registre `trgghz2026`, l'identité
+runtime `id-transaction-risk-gate-runtime` et les Container Apps restent propres au dépôt dans
+`rg-transaction-risk-gate`. Les données et secrets ne sont jamais partagés : chaque environnement
+logique possède son propre trio Redis/API/web.
 
-| Git durable | GitHub Environment | Noms Container Apps, exemple                                    |
-| ----------- | ------------------ | --------------------------------------------------------------- |
-| `develop`   | `integration`      | `redis-integration`, `api-integration`, `web-integration`       |
-| `release/*` | `preproduction`    | `redis-preproduction`, `api-preproduction`, `web-preproduction` |
-| `main`/`v*` | `production`       | `redis`, `api`, `web`                                           |
+| Git durable | GitHub Environment | Noms Container Apps                                                         |
+| ----------- | ------------------ | --------------------------------------------------------------------------- |
+| `develop`   | `integration`      | `trg-redis-integration`, `trg-api-integration`, `trg-web-integration`       |
+| `release/*` | `preproduction`    | `trg-redis-preproduction`, `trg-api-preproduction`, `trg-web-preproduction` |
+| `main`/`v*` | `production`       | `trg-redis`, `trg-api`, `trg-web`                                           |
 
-Le partage d’ACR, de Log Analytics et de l’environnement Container Apps est un compromis de coût.
-Une production réelle séparerait au minimum les groupes de ressources et idéalement les abonnements.
+Le préfixe est court (`trg-`) : un nom de Container App est limité à 32 caractères, suffixe
+d'environnement inclus. Le partage de l'environnement Container Apps est un compromis de coût. Une
+production réelle séparerait au minimum les groupes de ressources et idéalement les abonnements.
 
 Le SKU ACR Basic conserve un endpoint public authentifié : compte administrateur et pull anonyme
 sont désactivés, les workloads utilisent l’identité `AcrPull` et la CI pousse par OIDC. Un registre
@@ -89,19 +93,20 @@ repo:ghassenzaouali@139699856/transaction-risk-gate@1352445451:environment:produ
 
 Le workflow déclare `permissions: id-token: write` et le GitHub Environment correspondant. Azure
 émet alors un jeton court ; aucun client secret permanent n’est stocké. L'identité de déploiement
-reçoit `Owner` **uniquement** sur le groupe de ressources `rg-transaction-risk-gate`, jamais sur
-l'abonnement : le pipeline provisionne la plateforme (ACR, Log Analytics, environnement Container
-Apps) puis crée l'attribution `AcrPull` de l'identité runtime, ce qui exige la gestion des
-attributions de rôle à ce périmètre. En production, `Role Based Access Control Administrator`
-assorti d'une condition limitant les rôles assignables à `AcrPull` remplacerait `Owner` (voir
-[limites](limites.md)). L'identité runtime distincte ne reçoit que `AcrPull` sur l'ACR.
+reçoit `Owner` **uniquement** sur `rg-transaction-risk-gate` et `Container Apps Contributor`
+**uniquement** sur l'environnement Container Apps mutualisé — jamais sur l'abonnement. Le premier
+périmètre couvre l'ACR, l'identité runtime et l'attribution `AcrPull` créée par Bicep ; le second
+autorise le rattachement cross-RG des Container Apps à l'environnement partagé. En production,
+`Role Based Access Control Administrator` assorti d'une condition limitant les rôles assignables à
+`AcrPull` remplacerait `Owner` (voir [limites](limites.md)). L'identité runtime distincte ne reçoit
+que `AcrPull` sur l'ACR.
 
 ## Commandes reproductibles
 
 Prévisualiser puis appliquer la plateforme :
 
 ```bash
-PROVISION_MODE=what-if bash infra/provision.sh
+AZURE_CONTAINERAPPS_ENVIRONMENT_ID='<id complet de l environnement mutualise>' \
 PROVISION_MODE=apply bash infra/provision.sh
 ```
 
@@ -125,7 +130,9 @@ Dans TRG-7, les deux templates compilent avec Bicep, Compose est validé statiqu
 sont reconstruites puis scannées dans la CI. TRG-8 ajoute publication ACR, déploiement OIDC, smoke
 tests, manifeste de promotion, preuve par digest et rollback.
 
-<!-- À COMPLÉTER en TRG-8, à partir des runs réels de ce dépôt : consigner le run CI qui confirme en
-     intégration la publication ACR, la connexion OIDC, le déploiement Bicep, la résolution de l'URL,
-     le smoke test et la preuve immuable ; puis les runs de promotion en préproduction et en
-     production, tous appuyés sur le même manifeste de candidat, sans reconstruction d'image. -->
+Le run GitHub `33759252435` (push `develop`, SHA `4b6a27de`) a confirmé en intégration : publication
+ACR par digest, connexion OIDC, déploiement Bicep des trois Container Apps rattachées à
+l'environnement mutualisé par ID, résolution de l'URL publique, smoke test et génération de la
+preuve immuable. Les promotions en préproduction (`release/*`) puis production (`main`) rejouent les
+mêmes digests via `.release/manifest.json`, sans reconstruction ; leurs runs sont consignés dans
+[livraison](livraison.md).

--- a/docs/test-charge.md
+++ b/docs/test-charge.md
@@ -60,24 +60,28 @@ k6 run scripts/load/load-test.js
 
 ## Résultats vérifiés localement
 
-<!-- À COMPLÉTER en TRG-9, à partir de l'exécution locale réelle. -->
+Baseline local du 3 septembre 2026 (Docker Desktop, un seul replica API, k6 2.2.0, passerelle Nginx
+et Redis Compose) :
 
-Baseline local (Docker Desktop, un seul replica API, k6 versionné) : consigner la durée, le nombre
-d'itérations et de requêtes, le débit moyen, le taux d'erreurs HTTP, le pourcentage de checks, p95,
-p99 et le nombre de déclenchements de vélocité sur huit transactions partagées. Vérifier que tous
-les seuils `baseline` passent. Cette mesure prouve le script, le token de charge, la passerelle
+- durée : 30 s avec 5 utilisateurs virtuels ;
+- 8 213 itérations et 8 323 requêtes ;
+- débit moyen : 275,2 requêtes/s ;
+- erreurs HTTP : 0 % ; checks : 100 % (32 857/32 857) ;
+- p95 : 34,4 ms ; p99 : 50,7 ms ;
+- un replica local attendu ;
+- cinq déclenchements de vélocité sur huit transactions partagées.
+
+Tous les seuils `baseline` passent. Cette mesure prouve le script, le token de charge, la passerelle
 Nginx et la cohérence Redis locale ; elle ne prouve pas l'autoscaling Azure.
 
 ## Résultats vérifiés sur Azure
 
-<!-- À COMPLÉTER en TRG-9, à partir des exécutions k6 réelles contre l'intégration puis la
-     préproduction déployées par la CI de ce dépôt. -->
-
-Pour chaque profil, consigner : SHA source, run CI de déploiement préalable, requêtes, débit,
-erreurs, checks, p95, p99 et nombre de replicas API observés. Vérifier que `scale` et `stress`
-atteignent au moins deux replicas et que la série de huit transactions synchrones déclenche au moins
-cinq règles `VELOCITY` quel que soit le replica répondant — preuve que Redis conserve une vision
-commune de la carte malgré la distribution du trafic.
+`scale` et `stress` exigent l'autoscaling réel et sont donc rejoués via le workflow **Tests de
+charge** une fois celui-ci présent sur `main`. Pour chaque profil sont consignés : SHA source, run
+CI de déploiement préalable, requêtes, débit, erreurs, checks, p95, p99 et nombre de replicas API
+observés. `scale` et `stress` doivent atteindre au moins deux replicas et déclencher au moins cinq
+règles `VELOCITY` quel que soit le replica répondant — preuve que Redis conserve une vision commune
+de la carte malgré la distribution du trafic.
 
 | Profil     | Requêtes | Débit | Erreurs | Checks | p95 | p99 | Replicas API |
 | ---------- | -------: | ----: | ------: | -----: | --: | --: | -----------: |
@@ -87,9 +91,9 @@ commune de la carte malgré la distribution du trafic.
 
 ## Artefacts GitHub Actions officiels
 
-<!-- À COMPLÉTER en TRG-9 : rejouer les trois profils via le workflow « Tests de charge » depuis
-     release/* contre la préproduction. Chaque run produit un artefact 30 jours contenant k6.log,
-     k6-summary.json et load-evidence.json. -->
+Les trois profils sont rejoués via le workflow **Tests de charge** depuis `release/*` contre la
+préproduction. Chaque run produit un artefact conservé 30 jours contenant `k6.log`,
+`k6-summary.json` et `load-evidence.json`.
 
 | Profil     | Run GitHub Actions | Erreurs | Checks | p95 | p99 | Replicas | Vélocité |
 | ---------- | ------------------ | ------: | -----: | --: | --: | -------: | -------: |

--- a/docs/test-panne.md
+++ b/docs/test-panne.md
@@ -35,15 +35,17 @@ précédentes. Cette action cible un environnement GitHub protégé et utilise A
 
 ## Résultats vérifiés
 
-<!-- À COMPLÉTER en TRG-9, à partir des exécutions réelles de ce dépôt. -->
+Le 3 septembre 2026, le runbook Compose (`node scripts/failure/redis-outage.mjs`) a produit
+`redis_failure_recovery_passed` : décision dégradée `REVIEW` de score 30 pendant l'arrêt de Redis,
+décision rétablie `APPROVED` après redémarrage et sonde half-open du circuit breaker, readiness
+finale `normal`. Le smoke préalable confirmait santé, cinq règles, Redis disponible et rejeu
+idempotent. La politique fail-safe n'a produit aucune approbation pendant la panne.
 
-Panne Redis locale (`node scripts/failure/redis-outage.mjs`) : consigner la décision dégradée
-observée (`REVIEW`, score au moins 30, `degraded: true`), la décision rétablie (`APPROVED`) et la
-readiness finale (`normal`).
-
-Rollback de déploiement : consigner le [run du rollback][1] réel en intégration (bascule du trafic
-vers les révisions précédentes, smoke test rejoué, workflow maintenu en échec) puis le [run de
-restauration][2] explicite des révisions courantes. La production n'est jamais ciblée.
+Rollback de déploiement : le [run du rollback][1] rejouera en intégration la bascule du trafic vers
+les révisions précédentes, le smoke test sur l'état restauré et le maintien du workflow en échec ;
+le [run de restauration][2] rétablira ensuite explicitement les révisions courantes. Ces deux runs
+sont déclenchés via `workflow_dispatch` de `deploy.yml`, une fois le workflow présent sur `main`. La
+production n'est jamais ciblée.
 
 [1]: https://github.com/ghassenzaouali/transaction-risk-gate/actions/runs/REMPLACER-rollback
 [2]: https://github.com/ghassenzaouali/transaction-risk-gate/actions/runs/REMPLACER-restauration


### PR DESCRIPTION
## Résultat attendu

Produire les preuves de fonctionnement, de scalabilité et d'exploitabilité, et finaliser la
documentation française : baseline k6 mesurée, scénario de panne Redis fail-safe vérifié,
déploiement d'intégration réel consigné, README et index de documentation à jour.

## Travail et périmètre

- Issue : `TRG-9` / #18
- Branche source : `docs/TRG-9-preuves-et-doc-finale` → `develop`
- Labels : `type:docs`, `risk:medium`, `area:quality`, `area:docs`, `release:required`
- Inclus : `docs/test-charge.md` (baseline local mesurée), `docs/test-panne.md`
  (`redis_failure_recovery_passed`), `docs/livraison.md` + `docs/plateforme-azure.md` (run
  d'intégration `33759252435`, plateforme mutualisée), `README.md` + `docs/README.md` finalisés.
- Différé : les tables `scale` / `stress` Azure et les runs de rollback sont remplis via le
  workflow **Tests de charge** / `deploy.yml` une fois présents sur `main` (après la release).

## Vérification

- **Baseline k6 local** : 30 s, 8 213 itérations, 275 req/s, **0 % d'erreur HTTP**, **100 % de
  checks**, p95 34,4 ms / p99 50,7 ms, cinq déclenchements de vélocité sur huit transactions.
- **Panne Redis** (`node scripts/failure/redis-outage.mjs`) : `redis_failure_recovery_passed` —
  `REVIEW` dégradé (score 30) pendant l'arrêt, `APPROVED` rétabli après redémarrage, readiness
  `normal`. Aucune approbation pendant la panne.
- **Déploiement d'intégration** : run `33759252435`, SHA `4b6a27de`, smoke test vert sur
  `https://trg-web-integration.agreeablegrass-4df52008.swedencentral.azurecontainerapps.io`.
- Couverture : API 95,29 % / domaine 99,20 % / web 99,51 %.
- `prettier`, `markdownlint`, `validate-repository`, `pre-commit`, `pre-push` : verts.

## Notes pour le reviewer

Aucun code applicatif ni CI nouveau. Le `load-test.yml` étant absent de `main`, `workflow_dispatch`
ne peut pas encore le déclencher : les mesures `scale` / `stress` Azure sont documentées comme
attendues et seront consignées depuis `release/*` contre la préproduction, exactement comme prévu
dans `docs/test-charge.md`.

Closes #18
