### PR TITLE
[TRG-10] figer le manifeste de release v1.0.0

### DIFF
--- a/.release/manifest.json
+++ b/.release/manifest.json
@@ -1,0 +1,7 @@
+{
+  "version": "v1.0.0",
+  "sourceSha": "4b6a27debae388b38b02403867f95b6a4f0bd248",
+  "apiImage": "trgghz2026.azurecr.io/transaction-risk-gate-api@sha256:878ba79569e6123aab8092652dbec0b60db6cfc30649000cbd16d9c6be42d16d",
+  "webImage": "trgghz2026.azurecr.io/transaction-risk-gate-web@sha256:a4b2975c85ab6288244e443df99cfea9b7c508e19d3231d17d18dd07e3e98874",
+  "createdAt": "2026-09-03T13:50:00.000Z"
+}


### PR DESCRIPTION
## Résultat attendu

Figer le candidat validé en intégration pour la promotion : `.release/manifest.json` → `v1.0.0`,
SHA source et les deux digests ACR publiés et scannés par le run d'intégration.

## Travail et périmètre

- Issue : `TRG-10` / #28
- Branche source : `chore/TRG-10-freeze-release-manifest` → `develop`
- Labels : `type:chore`, `risk:high`, `area:infra`, `area:quality`, `release:required`
- Inclus : `.release/manifest.json` uniquement.
- Exclu : aucun changement de code, d'image ou de contexte de build.

## Candidat promu

| | |
|---|---|
| version | `v1.0.0` |
| sourceSha | `4b6a27debae388b38b02403867f95b6a4f0bd248` |
| apiImage | `transaction-risk-gate-api@sha256:878ba795…` |
| webImage | `transaction-risk-gate-web@sha256:a4b2975c…` |

## Vérification

- `AZURE_CONTAINER_REGISTRY=trgghz2026 node scripts/release/manifest.mjs` : `release_manifest_validated`
  (5 champs exacts, SemVer, SHA complet, digests ACR, registre attendu).
- `git diff --name-only 4b6a27de..develop -- api web` : **vide** — les digests représentent le code livré.
- Intégration déjà verte : run `33759252435`, smoke test passé, `/transaction-simulator.mjs` répond 200.

## Récupération

`release/v1.0.0` puis `main` consomment ce fichier. `resolve_promotion` échoue si `api/` ou `web/`
divergent du `sourceSha`. Rollback de déploiement automatique via smoke test.

Closes #28
