### PR TITLE
[TRG-10] exclure le serveur de dev local de l'analyse Sonar

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,9 @@ sonar.sourceEncoding=UTF-8
 
 sonar.sources=api/src,web
 sonar.tests=api/src,web
-sonar.exclusions=api/src/**/*.test.ts,api/src/test-helpers.ts,web/*.test.mjs,web/node_modules/**,web/coverage/**,api/dist/**,api/node_modules/**,api/coverage/**
+# web/dev-server.mjs est un stand-in local de nginx : exclu de l'image par .dockerignore,
+# jamais exécuté en production, remplacé par la configuration nginx. Hors périmètre d'analyse.
+sonar.exclusions=api/src/**/*.test.ts,api/src/test-helpers.ts,web/*.test.mjs,web/dev-server.mjs,web/node_modules/**,web/coverage/**,api/dist/**,api/node_modules/**,api/coverage/**
 sonar.test.inclusions=api/src/**/*.test.ts,api/src/test-helpers.ts,web/*.test.mjs
 
 sonar.javascript.lcov.reportPaths=api/coverage/lcov.info,web/coverage/lcov.info


### PR DESCRIPTION
## Résultat attendu

Le Quality Gate SonarCloud passe sur la PR `release/v1.0.0` → `main`. L'analyse contre `main` (au
commit d'initialisation) traite tout le code comme « nouveau » et signalait `web/dev-server.mjs:34`
(S5144, construction d'URL depuis une entrée utilisateur) → `new_security_rating` C.

## Travail et périmètre

- Issue : `TRG-10` / #28
- Branche : `fix/TRG-10-exclure-le-serveur-de-dev-de-sonar` → `develop`
- Labels : `type:fix`, `risk:low`, `area:quality`, `release:required`
- Inclus : `sonar-project.properties` — ajout de `web/dev-server.mjs` à `sonar.exclusions`.

## Justification

`web/dev-server.mjs` est un stand-in local de nginx : exclu de l'image par `.dockerignore`, jamais
exécuté en production, remplacé par `web/nginx.conf.template`. Le proxy applicatif réel (nginx)
n'accepte que le préfixe `/api/` et écrase l'en-tête `X-API-Key`. Le fichier reste hors périmètre
d'analyse de sécurité, comme les tests et `node_modules`.

## Vérification

- `validate-repository`, `prettier`, `markdownlint`, `pre-commit`, `pre-push` : verts.
- Après merge : `release/v1.0.0` est recréée depuis `develop` et son Quality Gate repasse.
