### PR TITLE
[TRG-10] réintégrer l'exclusion Sonar dans release/v1.0.0

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,9 @@ sonar.sourceEncoding=UTF-8
 
 sonar.sources=api/src,web
 sonar.tests=api/src,web
-sonar.exclusions=api/src/**/*.test.ts,api/src/test-helpers.ts,web/*.test.mjs,web/node_modules/**,web/coverage/**,api/dist/**,api/node_modules/**,api/coverage/**
+# web/dev-server.mjs est un stand-in local de nginx : exclu de l'image par .dockerignore,
+# jamais exécuté en production, remplacé par la configuration nginx. Hors périmètre d'analyse.
+sonar.exclusions=api/src/**/*.test.ts,api/src/test-helpers.ts,web/*.test.mjs,web/dev-server.mjs,web/node_modules/**,web/coverage/**,api/dist/**,api/node_modules/**,api/coverage/**
 sonar.test.inclusions=api/src/**/*.test.ts,api/src/test-helpers.ts,web/*.test.mjs
 
 sonar.javascript.lcov.reportPaths=api/coverage/lcov.info,web/coverage/lcov.info


### PR DESCRIPTION
## Résultat attendu

Aligner `release/v1.0.0` sur `develop` après le correctif SonarCloud (#31) : `web/dev-server.mjs` exclu de l'analyse. Le manifeste et les digests ACR ne changent pas.

## Périmètre

- Head : `develop` → base : `release/v1.0.0`
- Seul changement apporté : `sonar-project.properties` (via #31).
- Invariant de promotion : `git diff --name-only 4b6a27de..develop -- api web` **vide**.

## Vérification

Le Quality Gate SonarCloud repasse (vérifié sur #31). Après merge, la PR `release/v1.0.0` → `main` est recréée.