### PR TITLE
[TRG-11] finaliser les preuves de charge, de rollback et le CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@ Les changements notables suivent [Semantic Versioning](https://semver.org/lang/f
 promues sont identifiées dans le manifeste de release et ne sont jamais reconstruites entre les
 environnements.
 
-<!-- À COMPLÉTER en phase release : date réelle et périmètre exact livré. -->
+## v1.0.0 — 2026-09-03
 
-## v1.0.0 — AAAA-MM-JJ
-
-Première version de Transaction Risk Gate :
+Première version de Transaction Risk Gate, promue sans reconstruction depuis l'intégration jusqu'à
+la production (digests `transaction-risk-gate-api@sha256:878ba795…` et
+`transaction-risk-gate-web@sha256:a4b2975c…`) :
 
 - moteur explicable à cinq règles et décisions `APPROVED`, `REVIEW` ou `REJECTED` ;
 - vélocité et idempotence distribuées dans Redis, avec politique fail-safe en cas de panne ;
@@ -21,4 +21,4 @@ Première version de Transaction Risk Gate :
 - contrat OpenAPI, collection Postman et documentation française complète.
 
 Limites assumées : règles heuristiques, EUR uniquement, aucune authentification utilisateur ni
-persistance métier durable, Redis mono-replica et plateforme Azure mutualisée.
+persistance métier durable, Redis mono-replica et environnement Azure Container Apps mutualisé.

--- a/docs/test-charge.md
+++ b/docs/test-charge.md
@@ -76,34 +76,36 @@ Nginx et la cohérence Redis locale ; elle ne prouve pas l'autoscaling Azure.
 
 ## Résultats vérifiés sur Azure
 
-`scale` et `stress` exigent l'autoscaling réel et sont donc rejoués via le workflow **Tests de
-charge** une fois celui-ci présent sur `main`. Pour chaque profil sont consignés : SHA source, run
-CI de déploiement préalable, requêtes, débit, erreurs, checks, p95, p99 et nombre de replicas API
-observés. `scale` et `stress` doivent atteindre au moins deux replicas et déclencher au moins cinq
-règles `VELOCITY` quel que soit le replica répondant — preuve que Redis conserve une vision commune
-de la carte malgré la distribution du trafic.
+Le 3 septembre 2026, les trois profils ont été exécutés depuis `release/v1.0.0` contre la
+préproduction (SHA source `4b6a27de`, digests du manifeste `v1.0.0`, aucune reconstruction). `scale`
+et `stress` atteignent le maximum configuré de dix replicas et déclenchent cinq règles `VELOCITY`
+réparties sur plusieurs replicas distincts — Redis conserve une vision commune de la carte malgré la
+distribution du trafic.
 
-| Profil     | Requêtes | Débit | Erreurs | Checks | p95 | p99 | Replicas API |
-| ---------- | -------: | ----: | ------: | -----: | --: | --: | -----------: |
-| `baseline` |        — |     — |       — |      — |   — |   — |            — |
-| `scale`    |        — |     — |       — |      — |   — |   — |            — |
-| `stress`   |        — |     — |       — |      — |   — |   — |            — |
+| Profil     | Requêtes | Débit     | Erreurs | Checks | p95    | p99      | Replicas API |
+| ---------- | -------: | --------- | ------: | -----: | ------ | -------- | -----------: |
+| `baseline` |    1 187 | 36 req/s  |     0 % |  100 % | 153 ms | 167 ms   |            1 |
+| `scale`    |   50 269 | 275 req/s |     0 % |  100 % | 451 ms | 595 ms   |           10 |
+| `stress`   |   66 079 | 361 req/s |     0 % |  100 % | 843 ms | 1 102 ms |           10 |
+
+Les enveloppes de latence par profil (`250/500`, `750/1000`, `1250/1750` ms) sont respectées avec
+marge. `baseline` reste volontairement mono-replica : son objectif est la latence interactive, pas
+l'autoscaling.
 
 ## Artefacts GitHub Actions officiels
 
-Les trois profils sont rejoués via le workflow **Tests de charge** depuis `release/*` contre la
-préproduction. Chaque run produit un artefact conservé 30 jours contenant `k6.log`,
+Chaque run du workflow **Tests de charge** conserve 30 jours un artefact contenant `k6.log`,
 `k6-summary.json` et `load-evidence.json`.
 
-| Profil     | Run GitHub Actions | Erreurs | Checks | p95 | p99 | Replicas | Vélocité |
-| ---------- | ------------------ | ------: | -----: | --: | --: | -------: | -------: |
-| `baseline` | [`—`][1]           |       — |      — |   — |   — |        — |      —/8 |
-| `scale`    | [`—`][2]           |       — |      — |   — |   — |        — |      —/8 |
-| `stress`   | [`—`][3]           |       — |      — |   — |   — |        — |      —/8 |
+| Profil     | Run GitHub Actions | Erreurs | Checks | p95    | p99      | Replicas | Vélocité |
+| ---------- | ------------------ | ------: | -----: | ------ | -------- | -------: | -------: |
+| `baseline` | [`33769001273`][1] |     0 % |  100 % | 153 ms | 167 ms   |        1 |      5/8 |
+| `scale`    | [`33769498092`][2] |     0 % |  100 % | 451 ms | 595 ms   |       10 |      5/8 |
+| `stress`   | [`33769016355`][3] |     0 % |  100 % | 843 ms | 1 102 ms |       10 |      5/8 |
 
-Les artefacts bruts téléchargés pour vérification restent ignorés par Git. La documentation ne
-retient que les métriques stables, les identifiants de runs et l'interprétation reproductible.
+Sous `scale`, les cinq déclenchements de vélocité ont traversé cinq replicas distincts ; sous
+`stress`, sept. Les artefacts bruts téléchargés pour vérification restent ignorés par Git.
 
-[1]: https://github.com/ghassenzaouali/transaction-risk-gate/actions/runs/REMPLACER-baseline
-[2]: https://github.com/ghassenzaouali/transaction-risk-gate/actions/runs/REMPLACER-scale
-[3]: https://github.com/ghassenzaouali/transaction-risk-gate/actions/runs/REMPLACER-stress
+[1]: https://github.com/ghassenzaouali/transaction-risk-gate/actions/runs/33769001273
+[2]: https://github.com/ghassenzaouali/transaction-risk-gate/actions/runs/33769498092
+[3]: https://github.com/ghassenzaouali/transaction-risk-gate/actions/runs/33769016355

--- a/docs/test-panne.md
+++ b/docs/test-panne.md
@@ -41,11 +41,16 @@ décision rétablie `APPROVED` après redémarrage et sonde half-open du circuit
 finale `normal`. Le smoke préalable confirmait santé, cinq règles, Redis disponible et rejeu
 idempotent. La politique fail-safe n'a produit aucune approbation pendant la panne.
 
-Rollback de déploiement : le [run du rollback][1] rejouera en intégration la bascule du trafic vers
-les révisions précédentes, le smoke test sur l'état restauré et le maintien du workflow en échec ;
-le [run de restauration][2] rétablira ensuite explicitement les révisions courantes. Ces deux runs
-sont déclenchés via `workflow_dispatch` de `deploy.yml`, une fois le workflow présent sur `main`. La
-production n'est jamais ciblée.
+Rollback de déploiement : le [run de rollback][1] a basculé 100 % du trafic API et web de
+`trg-*-integration` de la révision `--0000003` vers la précédente `--0000002`, puis réussi le smoke
+test complet sur l'état restauré. Le [run de restauration][2] a ensuite rétabli explicitement les
+révisions courantes `--0000003`, smoke test vert. Les deux passent par `workflow_dispatch` de
+`deploy.yml` avec authentification OIDC ; la production n'est jamais ciblée.
 
-[1]: https://github.com/ghassenzaouali/transaction-risk-gate/actions/runs/REMPLACER-rollback
-[2]: https://github.com/ghassenzaouali/transaction-risk-gate/actions/runs/REMPLACER-restauration
+Note : lors du premier accès d'une nouvelle révision, le circuit breaker Redis peut mettre plus de
+180 s à passer en `half-open` sur l'environnement Container Apps mutualisé (démarrage à froid). Le
+smoke test est alors rejoué une fois la révision chaude, sans reconstruction ni changement de
+digest.
+
+[1]: https://github.com/ghassenzaouali/transaction-risk-gate/actions/runs/33770007667
+[2]: https://github.com/ghassenzaouali/transaction-risk-gate/actions/runs/33770128542


### PR DESCRIPTION
## Contexte

La version `v1.0.0` est en production depuis le [run de déploiement promu][deploy]. Trois
livrables documentaires restaient en attente des exécutions réelles qui n'existaient pas encore
au moment de la release :

- le `CHANGELOG` portait un gabarit de date (`AAAA-MM-JJ`) ;
- `docs/test-charge.md` annonçait des tables de résultats k6 Azure à compléter ;
- `docs/test-panne.md` décrivait le rollback sans preuve d'exécution.

Ces exécutions ont maintenant eu lieu. Ce hotfix consigne uniquement leurs résultats.

## Changements

| Fichier | Nature |
| --- | --- |
| `CHANGELOG.md` | date réelle `2026-09-03` pour `v1.0.0`, rappel des digests promus |
| `docs/test-charge.md` | tables `baseline` / `scale` / `stress` renseignées avec les mesures des runs [`33769001273`][k6b], [`33769498092`][k6s], [`33769016355`][k6t] (0 % d'erreur, 10 replicas sous charge, vélocité cohérente entre replicas) |
| `docs/test-panne.md` | rollback réel [`33770007667`][rb] et restauration [`33770128542`][rs] en intégration, note sur le démarrage à froid Redis |

**Aucun changement `api/` ou `web/`.** `git diff --name-only 4b6a27de..HEAD -- api web` est vide :
`resolve_promotion` reste satisfait et la production sera redéployée avec **les mêmes digests**,
sans reconstruction.

## Vérification

- `npm run build` + couverture API au vert localement
- `prettier` et `markdownlint` propres
- `validate-repository` : OK
- liens Markdown des trois documents résolus

## Suivi

Back-merge `main` → `develop` après fusion. Le code smell `typescript:S3776` sur le gestionnaire
d'erreurs Fastify (`api/src/app.ts`) est reporté à la prochaine version mineure : il touche `api/`
et n'a pas sa place dans un hotfix de documentation.

Clôt #35.

[deploy]: https://github.com/ghassenzaouali/transaction-risk-gate/actions/runs/33766825474
[k6b]: https://github.com/ghassenzaouali/transaction-risk-gate/actions/runs/33769001273
[k6s]: https://github.com/ghassenzaouali/transaction-risk-gate/actions/runs/33769498092
[k6t]: https://github.com/ghassenzaouali/transaction-risk-gate/actions/runs/33769016355
[rb]: https://github.com/ghassenzaouali/transaction-risk-gate/actions/runs/33770007667
[rs]: https://github.com/ghassenzaouali/transaction-risk-gate/actions/runs/33770128542
