### PR TITLE
[TRG-11] consigner l'URL de production et réintégrer le hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@ Les changements notables suivent [Semantic Versioning](https://semver.org/lang/f
 promues sont identifiées dans le manifeste de release et ne sont jamais reconstruites entre les
 environnements.
 
-<!-- À COMPLÉTER en phase release : date réelle et périmètre exact livré. -->
+## v1.0.0 — 2026-09-03
 
-## v1.0.0 — AAAA-MM-JJ
-
-Première version de Transaction Risk Gate :
+Première version de Transaction Risk Gate, promue sans reconstruction depuis l'intégration jusqu'à
+la production (digests `transaction-risk-gate-api@sha256:878ba795…` et
+`transaction-risk-gate-web@sha256:a4b2975c…`) :
 
 - moteur explicable à cinq règles et décisions `APPROVED`, `REVIEW` ou `REJECTED` ;
 - vélocité et idempotence distribuées dans Redis, avec politique fail-safe en cas de panne ;
@@ -21,4 +21,4 @@ Première version de Transaction Risk Gate :
 - contrat OpenAPI, collection Postman et documentation française complète.
 
 Limites assumées : règles heuristiques, EUR uniquement, aucune authentification utilisateur ni
-persistance métier durable, Redis mono-replica et plateforme Azure mutualisée.
+persistance métier durable, Redis mono-replica et environnement Azure Container Apps mutualisé.

--- a/README.md
+++ b/README.md
@@ -9,23 +9,24 @@ de démontrer comment concevoir, tester, sécuriser, livrer et exploiter un serv
 
 ## État vérifié
 
-| Élément                   | État                                                           |
-| ------------------------- | -------------------------------------------------------------- |
-| Domaine et API            | implémentés et testés                                          |
-| Couverture (lignes)       | API 95,29 %, domaine 99,20 %, web 99,51 %                      |
-| SonarCloud, Snyk et Trivy | bloquants et verts sur toute PR vers une branche durable       |
-| Images Docker et Compose  | images non-root, smoke local validé                            |
-| Déploiement Azure         | OIDC, ACR par digest, intégration déployée et smoke testée     |
-| Charge et panne           | baseline k6 local 0 % d'erreur ; panne Redis fail-safe validée |
+| Élément                   | État                                                                              |
+| ------------------------- | --------------------------------------------------------------------------------- |
+| Domaine et API            | implémentés et testés                                                             |
+| Couverture (lignes)       | API 95,29 %, domaine 99,20 %, web 99,51 %                                         |
+| SonarCloud, Snyk et Trivy | bloquants et verts sur toute PR vers une branche durable                          |
+| Images Docker et Compose  | images non-root, smoke local validé                                               |
+| Déploiement Azure         | OIDC, ACR par digest, promu jusqu'en production, smoke testé à chaque étape       |
+| Charge et panne           | k6 baseline/scale/stress 0 % d'erreur sur Azure ; panne Redis et rollback validés |
 
 Les résultats réels sont consignés dans [les tests de charge](docs/test-charge.md),
 [les scénarios de panne](docs/test-panne.md) et [les preuves de livraison](docs/livraison.md).
 
-Intégration vérifiée :
+Production : <https://trg-web.agreeablegrass-4df52008.swedencentral.azurecontainerapps.io>.
+Intégration :
 <https://trg-web-integration.agreeablegrass-4df52008.swedencentral.azurecontainerapps.io>.
 
 Préproduction et production sont déployées par promotion du même digest depuis `release/*` et
-`main`.
+`main`, sans reconstruction.
 
 ## Architecture
 

--- a/docs/test-charge.md
+++ b/docs/test-charge.md
@@ -76,34 +76,36 @@ Nginx et la cohérence Redis locale ; elle ne prouve pas l'autoscaling Azure.
 
 ## Résultats vérifiés sur Azure
 
-`scale` et `stress` exigent l'autoscaling réel et sont donc rejoués via le workflow **Tests de
-charge** une fois celui-ci présent sur `main`. Pour chaque profil sont consignés : SHA source, run
-CI de déploiement préalable, requêtes, débit, erreurs, checks, p95, p99 et nombre de replicas API
-observés. `scale` et `stress` doivent atteindre au moins deux replicas et déclencher au moins cinq
-règles `VELOCITY` quel que soit le replica répondant — preuve que Redis conserve une vision commune
-de la carte malgré la distribution du trafic.
+Le 3 septembre 2026, les trois profils ont été exécutés depuis `release/v1.0.0` contre la
+préproduction (SHA source `4b6a27de`, digests du manifeste `v1.0.0`, aucune reconstruction). `scale`
+et `stress` atteignent le maximum configuré de dix replicas et déclenchent cinq règles `VELOCITY`
+réparties sur plusieurs replicas distincts — Redis conserve une vision commune de la carte malgré la
+distribution du trafic.
 
-| Profil     | Requêtes | Débit | Erreurs | Checks | p95 | p99 | Replicas API |
-| ---------- | -------: | ----: | ------: | -----: | --: | --: | -----------: |
-| `baseline` |        — |     — |       — |      — |   — |   — |            — |
-| `scale`    |        — |     — |       — |      — |   — |   — |            — |
-| `stress`   |        — |     — |       — |      — |   — |   — |            — |
+| Profil     | Requêtes | Débit     | Erreurs | Checks | p95    | p99      | Replicas API |
+| ---------- | -------: | --------- | ------: | -----: | ------ | -------- | -----------: |
+| `baseline` |    1 187 | 36 req/s  |     0 % |  100 % | 153 ms | 167 ms   |            1 |
+| `scale`    |   50 269 | 275 req/s |     0 % |  100 % | 451 ms | 595 ms   |           10 |
+| `stress`   |   66 079 | 361 req/s |     0 % |  100 % | 843 ms | 1 102 ms |           10 |
+
+Les enveloppes de latence par profil (`250/500`, `750/1000`, `1250/1750` ms) sont respectées avec
+marge. `baseline` reste volontairement mono-replica : son objectif est la latence interactive, pas
+l'autoscaling.
 
 ## Artefacts GitHub Actions officiels
 
-Les trois profils sont rejoués via le workflow **Tests de charge** depuis `release/*` contre la
-préproduction. Chaque run produit un artefact conservé 30 jours contenant `k6.log`,
+Chaque run du workflow **Tests de charge** conserve 30 jours un artefact contenant `k6.log`,
 `k6-summary.json` et `load-evidence.json`.
 
-| Profil     | Run GitHub Actions | Erreurs | Checks | p95 | p99 | Replicas | Vélocité |
-| ---------- | ------------------ | ------: | -----: | --: | --: | -------: | -------: |
-| `baseline` | [`—`][1]           |       — |      — |   — |   — |        — |      —/8 |
-| `scale`    | [`—`][2]           |       — |      — |   — |   — |        — |      —/8 |
-| `stress`   | [`—`][3]           |       — |      — |   — |   — |        — |      —/8 |
+| Profil     | Run GitHub Actions | Erreurs | Checks | p95    | p99      | Replicas | Vélocité |
+| ---------- | ------------------ | ------: | -----: | ------ | -------- | -------: | -------: |
+| `baseline` | [`33769001273`][1] |     0 % |  100 % | 153 ms | 167 ms   |        1 |      5/8 |
+| `scale`    | [`33769498092`][2] |     0 % |  100 % | 451 ms | 595 ms   |       10 |      5/8 |
+| `stress`   | [`33769016355`][3] |     0 % |  100 % | 843 ms | 1 102 ms |       10 |      5/8 |
 
-Les artefacts bruts téléchargés pour vérification restent ignorés par Git. La documentation ne
-retient que les métriques stables, les identifiants de runs et l'interprétation reproductible.
+Sous `scale`, les cinq déclenchements de vélocité ont traversé cinq replicas distincts ; sous
+`stress`, sept. Les artefacts bruts téléchargés pour vérification restent ignorés par Git.
 
-[1]: https://github.com/ghassenzaouali/transaction-risk-gate/actions/runs/REMPLACER-baseline
-[2]: https://github.com/ghassenzaouali/transaction-risk-gate/actions/runs/REMPLACER-scale
-[3]: https://github.com/ghassenzaouali/transaction-risk-gate/actions/runs/REMPLACER-stress
+[1]: https://github.com/ghassenzaouali/transaction-risk-gate/actions/runs/33769001273
+[2]: https://github.com/ghassenzaouali/transaction-risk-gate/actions/runs/33769498092
+[3]: https://github.com/ghassenzaouali/transaction-risk-gate/actions/runs/33769016355

--- a/docs/test-panne.md
+++ b/docs/test-panne.md
@@ -41,11 +41,16 @@ décision rétablie `APPROVED` après redémarrage et sonde half-open du circuit
 finale `normal`. Le smoke préalable confirmait santé, cinq règles, Redis disponible et rejeu
 idempotent. La politique fail-safe n'a produit aucune approbation pendant la panne.
 
-Rollback de déploiement : le [run du rollback][1] rejouera en intégration la bascule du trafic vers
-les révisions précédentes, le smoke test sur l'état restauré et le maintien du workflow en échec ;
-le [run de restauration][2] rétablira ensuite explicitement les révisions courantes. Ces deux runs
-sont déclenchés via `workflow_dispatch` de `deploy.yml`, une fois le workflow présent sur `main`. La
-production n'est jamais ciblée.
+Rollback de déploiement : le [run de rollback][1] a basculé 100 % du trafic API et web de
+`trg-*-integration` de la révision `--0000003` vers la précédente `--0000002`, puis réussi le smoke
+test complet sur l'état restauré. Le [run de restauration][2] a ensuite rétabli explicitement les
+révisions courantes `--0000003`, smoke test vert. Les deux passent par `workflow_dispatch` de
+`deploy.yml` avec authentification OIDC ; la production n'est jamais ciblée.
 
-[1]: https://github.com/ghassenzaouali/transaction-risk-gate/actions/runs/REMPLACER-rollback
-[2]: https://github.com/ghassenzaouali/transaction-risk-gate/actions/runs/REMPLACER-restauration
+Note : lors du premier accès d'une nouvelle révision, le circuit breaker Redis peut mettre plus de
+180 s à passer en `half-open` sur l'environnement Container Apps mutualisé (démarrage à froid). Le
+smoke test est alors rejoué une fois la révision chaude, sans reconstruction ni changement de
+digest.
+
+[1]: https://github.com/ghassenzaouali/transaction-risk-gate/actions/runs/33770007667
+[2]: https://github.com/ghassenzaouali/transaction-risk-gate/actions/runs/33770128542


### PR DESCRIPTION
## Contexte

Deux suites après la mise en production de `v1.0.0` :

1. **Réintégration du hotfix.** Le [hotfix #36][hotfix] a été fusionné dans `main` sans jamais
   revenir vers `develop` — comme les merges de finalisation de `release/v1.0.0` (#30, #32).
   Cette PR ramène `main` dans `develop` : `develop` retrouve la date réelle du `CHANGELOG`, les
   tables k6 Azure et la preuve de rollback.
2. **URL de production dans le `README`.** Le `README` ne citait que l'intégration. Il indique
   maintenant aussi la production, vérifiée en ligne (`/ready` → `mode: normal`, Redis disponible) :
   <https://trg-web.agreeablegrass-4df52008.swedencentral.azurecontainerapps.io>

## Changements propres à cette branche

| Fichier | Nature |
| --- | --- |
| `README.md` | ajout de l'URL de production ; « État vérifié » actualisé (promotion jusqu'en production, k6 `baseline`/`scale`/`stress` sur Azure, rollback validé) |

Le reste du diff (`CHANGELOG.md`, `docs/test-charge.md`, `docs/test-panne.md`) provient du merge
de `main` : contenu déjà revu en #36.

## Vérification

- `prettier` et `markdownlint` propres
- `validate-repository` : OK
- production et intégration répondent `200` sur `/healthz`, `mode: normal` sur `/ready`

[hotfix]: https://github.com/ghassenzaouali/transaction-risk-gate/pull/36
